### PR TITLE
fix(ui): force Android to show camera option on guest uploads

### DIFF
--- a/frontend/src/components/gallery/UserPhotoUpload.tsx
+++ b/frontend/src/components/gallery/UserPhotoUpload.tsx
@@ -56,10 +56,7 @@ export const UserPhotoUpload: React.FC<UserPhotoUploadProps> = ({
     [publicSettings?.allowed_file_types]
   );
 
-  //const acceptString = useMemo(
-  //  () => extensionsToAcceptString(publicSettings?.allowed_file_types),
-  //  [publicSettings?.allowed_file_types]
-  //);
+  // Force newer Android phones to fallback to file picker with camera option
   const acceptString = useMemo(() => {
     const baseAccept = extensionsToAcceptString(publicSettings?.allowed_file_types);
     // Append .pdf to force Android's system chooser (showing the Camera option)

--- a/frontend/src/components/gallery/UserPhotoUpload.tsx
+++ b/frontend/src/components/gallery/UserPhotoUpload.tsx
@@ -56,10 +56,16 @@ export const UserPhotoUpload: React.FC<UserPhotoUploadProps> = ({
     [publicSettings?.allowed_file_types]
   );
 
-  const acceptString = useMemo(
-    () => extensionsToAcceptString(publicSettings?.allowed_file_types),
-    [publicSettings?.allowed_file_types]
-  );
+  //const acceptString = useMemo(
+  //  () => extensionsToAcceptString(publicSettings?.allowed_file_types),
+  //  [publicSettings?.allowed_file_types]
+  //);
+  const acceptString = useMemo(() => {
+    const baseAccept = extensionsToAcceptString(publicSettings?.allowed_file_types);
+    // Append .pdf to force Android's system chooser (showing the Camera option)
+    // instead of defaulting to the restricted photo picker
+    return baseAccept ? `${baseAccept}, .pdf` : 'image/*, .pdf';
+  }, [publicSettings?.allowed_file_types]);
 
   // #821 — the requirements hint used to hardcode "JPEG, PNG or WebP"; render
   // the actually-configured formats so it never contradicts what's accepted.
@@ -71,6 +77,11 @@ export const UserPhotoUpload: React.FC<UserPhotoUploadProps> = ({
   // Shared filter pipeline for both <input> change and drag-and-drop (#504).
   const addFiles = (incoming: File[]) => {
     const validFiles = incoming.filter((file) => {
+      // Reject non-image files explicitly (e.g. if selected via the .pdf chooser workaround)
+      if (!file.type.startsWith('image/')) {
+        toast.error(`Please select an image file: ${file.name}`);
+        return false;
+      }
       if (!allowedMimeTypes.includes(file.type)) {
         toast.error(`Invalid file type: ${file.name}`);
         return false;


### PR DESCRIPTION
## Description

Currently Android users cannot select the Camera input on Guest Upload modal. This change forces Android to show the legacy picker with camera option. No impact on iOS or desktop users.

This is a workaround for Androids sub-optimal behavior.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Unit tests pass (`npm test`)
- [x] Manual testing completed
- [x] Tested on Docker deployment
- [x] Tested on production-like environment

**Test Configuration**:
* PicPeak Version: 3.46.1 and 3.108.1-beta.0
* Node.js Version: 18.19.1
* Database: PostgreSQL 15.19
* Browser: Firefox 154.0, Chromium 151.0.7922.137, Chrome 151.0.7922.169 (Android 16), Orion 1.5.1 (Webkit 8624.4.5.10.5, iOS26.6)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [ ] I have updated the CHANGELOG.md file

## Screenshots (if appropriate):

## Additional Notes:

This is a workaround, might need reverting in the future.