### PR TITLE
fix(upload): let Android guests reach the camera without breaking video

### DIFF
--- a/frontend/src/components/gallery/UserPhotoUpload.tsx
+++ b/frontend/src/components/gallery/UserPhotoUpload.tsx
@@ -5,7 +5,7 @@ import { toast } from 'react-toastify';
 import { Button } from '../common';
 import { api } from '../../config/api';
 import { usePublicSettings } from '../../hooks/usePublicSettings';
-import { extensionsToMimeTypes, extensionsToAcceptString, extensionsToLabel } from '../../utils/fileTypes';
+import { extensionsToMimeTypes, buildUploadAcceptString, extensionsToLabel } from '../../utils/fileTypes';
 
 interface UserPhotoUploadProps {
   eventId: number;
@@ -56,8 +56,10 @@ export const UserPhotoUpload: React.FC<UserPhotoUploadProps> = ({
     [publicSettings?.allowed_file_types]
   );
 
+  // #1117 — on Android this appends a type the photo picker can't handle, so
+  // the system falls back to the chooser that actually offers the camera.
   const acceptString = useMemo(
-    () => extensionsToAcceptString(publicSettings?.allowed_file_types),
+    () => buildUploadAcceptString(publicSettings?.allowed_file_types),
     [publicSettings?.allowed_file_types]
   );
 

--- a/frontend/src/utils/__tests__/fileTypes.test.ts
+++ b/frontend/src/utils/__tests__/fileTypes.test.ts
@@ -40,6 +40,7 @@ describe('fileTypes', () => {
     const ANDROID = 'Mozilla/5.0 (Linux; Android 16; Pixel 9) AppleWebKit/537.36 Chrome/151.0.0.0 Mobile Safari/537.36';
     const IOS = 'Mozilla/5.0 (iPhone; CPU iPhone OS 26_6 like Mac OS X) AppleWebKit/605.1.15 Version/26.0 Mobile Safari/604.1';
     const DESKTOP = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/151.0.0.0 Safari/537.36';
+    const FIREFOX_ANDROID = 'Mozilla/5.0 (Android 16; Mobile; rv:140.0) Gecko/140.0 Firefox/140.0';
 
     it('appends the camera token on Android so the chooser offers the camera', () => {
       expect(buildUploadAcceptString('jpg,png', ANDROID)).toBe('image/jpeg,image/png,android/allowCamera');
@@ -55,6 +56,11 @@ describe('fileTypes', () => {
         .toEqual(['image/jpeg', 'image/png']);
     });
 
+
+    it('leaves Firefox for Android alone — its chooser already offers the camera', () => {
+      // The UA says Android, but the behaviour this works around is Chromium's.
+      expect(buildUploadAcceptString('jpg,png', FIREFOX_ANDROID)).toBe('image/jpeg,image/png');
+    });
     it('leaves iOS and desktop untouched — their pickers already work', () => {
       expect(buildUploadAcceptString('jpg,png', IOS)).toBe('image/jpeg,image/png');
       expect(buildUploadAcceptString('jpg,png', DESKTOP)).toBe('image/jpeg,image/png');

--- a/frontend/src/utils/__tests__/fileTypes.test.ts
+++ b/frontend/src/utils/__tests__/fileTypes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { extensionsToMimeTypes, extensionsToAcceptString, extensionsToLabel } from '../fileTypes';
+import { extensionsToMimeTypes, extensionsToAcceptString, extensionsToLabel, buildUploadAcceptString } from '../fileTypes';
 
 describe('fileTypes', () => {
   describe('extensionsToMimeTypes', () => {
@@ -33,6 +33,32 @@ describe('fileTypes', () => {
   describe('extensionsToAcceptString', () => {
     it('joins MIME types for the input accept attribute', () => {
       expect(extensionsToAcceptString('jpg,heic')).toBe('image/jpeg,image/heic');
+    });
+  });
+
+  describe('buildUploadAcceptString (#1117)', () => {
+    const ANDROID = 'Mozilla/5.0 (Linux; Android 16; Pixel 9) AppleWebKit/537.36 Chrome/151.0.0.0 Mobile Safari/537.36';
+    const IOS = 'Mozilla/5.0 (iPhone; CPU iPhone OS 26_6 like Mac OS X) AppleWebKit/605.1.15 Version/26.0 Mobile Safari/604.1';
+    const DESKTOP = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/151.0.0.0 Safari/537.36';
+
+    it('appends .pdf on Android so the chooser offers the camera', () => {
+      expect(buildUploadAcceptString('jpg,png', ANDROID)).toBe('image/jpeg,image/png,.pdf');
+    });
+
+    it('leaves iOS and desktop untouched — their pickers already work', () => {
+      expect(buildUploadAcceptString('jpg,png', IOS)).toBe('image/jpeg,image/png');
+      expect(buildUploadAcceptString('jpg,png', DESKTOP)).toBe('image/jpeg,image/png');
+    });
+
+    it('keeps offering video when the admin configured it', () => {
+      // The workaround must not narrow the accept list to images: an install
+      // with video enabled still has to offer mp4/mov in the chooser.
+      expect(buildUploadAcceptString('jpg,mp4,mov', ANDROID)).toBe('image/jpeg,video/mp4,video/quicktime,.pdf');
+    });
+
+    it('falls back to the configured default set, not a wider image/*', () => {
+      expect(buildUploadAcceptString('', DESKTOP)).toBe('image/jpeg,image/png,image/webp');
+      expect(buildUploadAcceptString('', ANDROID)).toBe('image/jpeg,image/png,image/webp,.pdf');
     });
   });
 });

--- a/frontend/src/utils/__tests__/fileTypes.test.ts
+++ b/frontend/src/utils/__tests__/fileTypes.test.ts
@@ -41,8 +41,18 @@ describe('fileTypes', () => {
     const IOS = 'Mozilla/5.0 (iPhone; CPU iPhone OS 26_6 like Mac OS X) AppleWebKit/605.1.15 Version/26.0 Mobile Safari/604.1';
     const DESKTOP = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/151.0.0.0 Safari/537.36';
 
-    it('appends .pdf on Android so the chooser offers the camera', () => {
-      expect(buildUploadAcceptString('jpg,png', ANDROID)).toBe('image/jpeg,image/png,.pdf');
+    it('appends the camera token on Android so the chooser offers the camera', () => {
+      expect(buildUploadAcceptString('jpg,png', ANDROID)).toBe('image/jpeg,image/png,android/allowCamera');
+    });
+
+    it('adds nothing a guest could actually select', () => {
+      // The token exists to flip Chrome out of the photo picker, not to widen
+      // the allowlist. An earlier revision used .pdf, which does flip it but
+      // also offers PDFs — pick one and you get "Invalid file type".
+      const accept = buildUploadAcceptString('jpg,png', ANDROID);
+      expect(accept).not.toMatch(/\.pdf|application\/pdf/);
+      expect(accept.split(',').filter((t) => t.startsWith('image/') || t.startsWith('video/')))
+        .toEqual(['image/jpeg', 'image/png']);
     });
 
     it('leaves iOS and desktop untouched — their pickers already work', () => {
@@ -53,12 +63,12 @@ describe('fileTypes', () => {
     it('keeps offering video when the admin configured it', () => {
       // The workaround must not narrow the accept list to images: an install
       // with video enabled still has to offer mp4/mov in the chooser.
-      expect(buildUploadAcceptString('jpg,mp4,mov', ANDROID)).toBe('image/jpeg,video/mp4,video/quicktime,.pdf');
+      expect(buildUploadAcceptString('jpg,mp4,mov', ANDROID)).toBe('image/jpeg,video/mp4,video/quicktime,android/allowCamera');
     });
 
     it('falls back to the configured default set, not a wider image/*', () => {
       expect(buildUploadAcceptString('', DESKTOP)).toBe('image/jpeg,image/png,image/webp');
-      expect(buildUploadAcceptString('', ANDROID)).toBe('image/jpeg,image/png,image/webp,.pdf');
+      expect(buildUploadAcceptString('', ANDROID)).toBe('image/jpeg,image/png,image/webp,android/allowCamera');
     });
   });
 });

--- a/frontend/src/utils/fileTypes.ts
+++ b/frontend/src/utils/fileTypes.ts
@@ -68,7 +68,12 @@ export function extensionsToAcceptString(extString?: string | null): string {
  * `.pdf`, which works by the same mechanism but offers PDFs in the chooser —
  * pick one and you get "Invalid file type" for your trouble.
  *
- * Gated on the UA because iOS, desktop and Firefox pickers behave correctly.
+ * Gated to Android MINUS Firefox. The behaviour is Chromium's — Chrome and
+ * Edge on Android 14/15 — and Firefox for Android, whose UA also says
+ * `Android`, opens a chooser that already offers the camera. Handing it a
+ * token invented to reroute a picker it does not use is at best inert and at
+ * worst changes a chooser that was working.
+ *
  * UA sniffing is the wrong tool in general, but there is no feature query for
  * "which picker will this open", and the failure mode of a wrong guess is an
  * accept token the browser ignores.
@@ -80,7 +85,8 @@ export function extensionsToAcceptString(extString?: string | null): string {
 export function buildUploadAcceptString(extString?: string | null, userAgent?: string): string {
   const accept = extensionsToAcceptString(extString);
   const ua = userAgent ?? (typeof navigator !== 'undefined' ? navigator.userAgent : '');
-  return /Android/i.test(ua) ? `${accept},android/allowCamera` : accept;
+  const needsCameraToken = /Android/i.test(ua) && !/Firefox/i.test(ua);
+  return needsCameraToken ? `${accept},android/allowCamera` : accept;
 }
 
 /**

--- a/frontend/src/utils/fileTypes.ts
+++ b/frontend/src/utils/fileTypes.ts
@@ -55,26 +55,32 @@ export function extensionsToAcceptString(extString?: string | null): string {
 /**
  * `accept` for the guest upload input (#1117).
  *
- * Recent Android versions route an `<input>` whose accept list is entirely
- * image and video types to the system *photo picker*, which has no camera
- * entry — so a guest at the event cannot take a photo, only pick one already
- * in their gallery. Including a type the photo picker can't handle forces
- * Android back to the general document chooser, which does offer the camera.
+ * Chrome and Edge on Android 14/15 route an `<input>` whose accept list is
+ * entirely image and video types to the system *photo picker*, which has no
+ * camera tile — so a guest standing at the event can only pick a photo already
+ * in their gallery, never take one. Adding a value that picker cannot satisfy
+ * makes Chrome fall back to the general document chooser, which does offer the
+ * camera.
  *
- * Gated on the UA because iOS and desktop pickers behave correctly and would
- * only gain a selectable PDF that `addFiles` then rejects. Picking one on
- * Android is rejected the same way — `extensionsToMimeTypes` only ever emits
- * types it has a mapping for, so `application/pdf` can never be in the
- * allowlist and the existing "Invalid file type" guard already covers it.
+ * `android/allowCamera` is the token the workaround converged on. It is not a
+ * real MIME type and matches no file, which is the point: it flips the picker
+ * without advertising anything extra as selectable. An earlier revision used
+ * `.pdf`, which works by the same mechanism but offers PDFs in the chooser —
+ * pick one and you get "Invalid file type" for your trouble.
  *
+ * Gated on the UA because iOS, desktop and Firefox pickers behave correctly.
  * UA sniffing is the wrong tool in general, but there is no feature query for
- * "which picker will this open"; the failure mode of a wrong guess is one
- * extra unusable entry in a file chooser.
+ * "which picker will this open", and the failure mode of a wrong guess is an
+ * accept token the browser ignores.
+ *
+ * Neither token widens what is actually accepted: `addFiles` validates every
+ * file against `extensionsToMimeTypes`, which only ever emits types it has a
+ * mapping for, so nothing new can get past it.
  */
 export function buildUploadAcceptString(extString?: string | null, userAgent?: string): string {
   const accept = extensionsToAcceptString(extString);
   const ua = userAgent ?? (typeof navigator !== 'undefined' ? navigator.userAgent : '');
-  return /Android/i.test(ua) ? `${accept},.pdf` : accept;
+  return /Android/i.test(ua) ? `${accept},android/allowCamera` : accept;
 }
 
 /**

--- a/frontend/src/utils/fileTypes.ts
+++ b/frontend/src/utils/fileTypes.ts
@@ -53,6 +53,31 @@ export function extensionsToAcceptString(extString?: string | null): string {
 }
 
 /**
+ * `accept` for the guest upload input (#1117).
+ *
+ * Recent Android versions route an `<input>` whose accept list is entirely
+ * image and video types to the system *photo picker*, which has no camera
+ * entry — so a guest at the event cannot take a photo, only pick one already
+ * in their gallery. Including a type the photo picker can't handle forces
+ * Android back to the general document chooser, which does offer the camera.
+ *
+ * Gated on the UA because iOS and desktop pickers behave correctly and would
+ * only gain a selectable PDF that `addFiles` then rejects. Picking one on
+ * Android is rejected the same way — `extensionsToMimeTypes` only ever emits
+ * types it has a mapping for, so `application/pdf` can never be in the
+ * allowlist and the existing "Invalid file type" guard already covers it.
+ *
+ * UA sniffing is the wrong tool in general, but there is no feature query for
+ * "which picker will this open"; the failure mode of a wrong guess is one
+ * extra unusable entry in a file chooser.
+ */
+export function buildUploadAcceptString(extString?: string | null, userAgent?: string): string {
+  const accept = extensionsToAcceptString(extString);
+  const ua = userAgent ?? (typeof navigator !== 'undefined' ? navigator.userAgent : '');
+  return /Android/i.test(ua) ? `${accept},.pdf` : accept;
+}
+
+/**
  * Human-readable, de-duplicated list of the configured extensions for the
  * upload requirements hint, e.g. "JPG, PNG, WEBP, MOV". Only extensions the
  * app actually supports (present in EXTENSION_TO_MIME) are shown, so the hint


### PR DESCRIPTION
Replaces #1117 (@Zszywany), keeping the diagnosis and crediting the author. Opened as a separate branch rather than pushed onto the contributor's fork `main`.

## The problem

Chrome and Edge on **Android 14/15** route an `<input>` whose `accept` list is entirely image/video types to the system **photo picker**, which has no camera tile. A guest standing at the event can only pick a photo already in their gallery, never take one. Adding a value that picker cannot satisfy makes Chrome fall back to the general document chooser, which does offer the camera.

## What changed vs #1117

**1. The token is `android/allowCamera`, not `.pdf`.** Same mechanism — the workaround converged on this token, which is not a real MIME type and matches no file. `.pdf` also flips the picker but *advertises PDFs as selectable*, so a guest can pick one and get "Invalid file type" for their trouble. A dead end we'd have put in front of them ourselves.

**2. Gated to Android minus Firefox.** #1117 appended unconditionally, so desktop and iOS pickers — which behave correctly — gained a selectable PDF. The behaviour is Chromium's; Firefox for Android matches `/Android/` but opens a chooser that already works, so it's excluded.

**3. No image-only guard.** #1117 rejected every non-image *before* the existing allowlist check:

```js
if (!file.type.startsWith('image/')) { toast.error(...); return false; }
if (!allowedMimeTypes.includes(file.type)) { ... }
```

`fileTypes.ts` maps `mp4`, `m4v`, `webm`, `mov` and `avi`, and `general_allowed_file_types` is a free-text admin setting. On any install configured for video, `acceptString` still offered videos in the chooser and this guard then refused them — an enabled feature broken in the guest path. It was also redundant: `extensionsToMimeTypes` only emits types it has a mapping for, so `application/pdf` could never be in `allowedMimeTypes` and the pre-existing check already covered it.

The `'image/*, .pdf'` empty-string fallback goes too — `extensionsToMimeTypes` already falls back to the configured default set, and `image/*` was broader than the admin's allowlist.

## Screenshot

![accept comparison](https://raw.githubusercontent.com/PicPeak/picpeak/screenshots/android-camera-accept-1117/android-1117-accept-comparison.png)

Real `UserPhotoUpload` rendered in Chromium, one build, only the user agent differs; each `accept` value is read back from the live DOM.

**What this proves:** the app emits the camera token on Android and nothing extra elsewhere, the modal is visually identical, and the format hint still reads "JPG, JPEG, PNG, WEBP" — the token never reaches anything a guest sees.

**What it does not prove:** that the native Android chooser then shows the camera. That needs a handset, and I don't have one. The mechanism is independently documented ([addpipe](https://blog.addpipe.com/html-file-input-accept-video-camera-option-is-missing-android-14-15/)), which is what raised my confidence from "reporter's word" to "known behaviour" — but the source says Android 14/15 while @Zszywany reported it on Android 16, so one device check would settle both the premise and that discrepancy.

If the premise turns out wrong, the blast radius is one inert token in the accept list on Android, and the revert is one line.

## Tests

14 in `fileTypes.test.ts`, including the ones that matter:

- the token is appended on Android and **nothing selectable is added** (the `.pdf` regression)
- iOS, desktop and **Firefox for Android** are untouched
- a video-enabled install still gets `video/mp4,video/quicktime` — the regression #1117 would have shipped
- the empty fallback stays at the configured default rather than widening to `image/*`

## Reviewed

Codex review, two rounds. Round one clean; round two flagged the Firefox gap, fixed here.
