### PR TITLE
chore: keep issue screenshots out of the source tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,16 @@ backend/storage/
 # committed 16 .pyc files here in #1247.
 __pycache__/
 *.pyc
+
+# Issue / PR screenshots belong on a `screenshots/*` branch, never on main or
+# stable — that is what those branches exist for. Two landed at the repo root
+# on main in #1241 and shipped as part of the source tree; nothing stopped it.
+#
+# Anchored with a leading slash so docs/ keeps its own images.
+/issue-*.png
+/issue-*.jpg
+/screenshot-*.png
+/screenshot-*.jpg
+/*-screenshot.png
+/*-screenshot.jpg
+


### PR DESCRIPTION
Preventative twin of #1259.

This branch has **no stray images to remove** — it gets the guard alone, so the two branches agree and a backport can't carry one across.

## Background

Two PR screenshots landed at main's repo root in #1241 and have been shipping as part of the source tree. Screenshots belong on a `screenshots/*` branch, which is how every other UI change here has attached its evidence.

## The rules are anchored deliberately

```
/issue-*.png
/screenshot-*.png
/*-screenshot.png
```

The leading slash matters: `docs/` legitimately holds images that a bare `screenshot-*.png` would have swallowed, and `test-assets/img1.png` / `img2.png` are fixtures the e2e specs load.

Verified by piping every tracked file on this branch through `git check-ignore`: nothing matches.
