### PR TITLE
fix(gallery): stop invisible overlay controls swallowing mobile taps (#1263)

### DIFF
--- a/frontend/src/components/gallery/PhotoCard.tsx
+++ b/frontend/src/components/gallery/PhotoCard.tsx
@@ -9,6 +9,26 @@ import { ColorLabelBadge } from './ColorLabelBadge';
 import { useGuestIdentityOptional } from '../../contexts/GuestIdentityContext';
 import type { Photo } from '../../types';
 
+const COARSE_POINTER_QUERY = '(hover: none) and (pointer: coarse)';
+
+/**
+ * Does this device lack hover? Read synchronously at first render rather than
+ * in an effect: every layout runs this now (#1263), and a mount-time state
+ * change here would land an extra render between the tile measurement in
+ * useLayoutEffect and the image mount it gates, remounting each card once.
+ *
+ * matchMedia is missing in some test environments and old embedded webviews,
+ * so the other two signals stand in for it.
+ */
+function detectCoarsePointer(): boolean {
+  if (typeof window === 'undefined') return false;
+  const hasNavigator = typeof navigator !== 'undefined';
+  const fallback = ('ontouchstart' in window)
+    || (hasNavigator && navigator.maxTouchPoints > 0);
+  if (typeof window.matchMedia !== 'function') return fallback;
+  return window.matchMedia(COARSE_POINTER_QUERY).matches || fallback;
+}
+
 export interface PhotoCardFeedbackOptions {
   allowLikes?: boolean;
   allowFavorites?: boolean;
@@ -37,9 +57,11 @@ export interface PhotoCardProps {
   skeletonClassName?: string;
   /** Keep container at opacity 0 until in view (only meaningful with `lazy`). */
   fadeInWhenVisible?: boolean;
-  /** Tap-to-reveal overlay state machine for touch devices (Grid/Justified). */
-  touchAware?: boolean;
-  /** Static overlay classes; `touchAware` appends computed visibility classes. */
+  /**
+   * Static overlay classes — positioning, backdrop, spacing. Visibility and
+   * hit-testing are owned by this component for every layout (#1263), so a
+   * layout must NOT pass its own `opacity-*` / `group-hover:*` here.
+   */
   overlayBaseClassName: string;
   /** 'light' = white/90 buttons with dark icons; 'dark' = white/20 buttons with white icons. */
   actionVariant?: 'light' | 'dark';
@@ -84,7 +106,6 @@ export const PhotoCard: React.FC<PhotoCardProps> = ({
   inViewRootMargin,
   skeletonClassName = 'skeleton w-full h-full rounded-lg',
   fadeInWhenVisible = false,
-  touchAware = false,
   overlayBaseClassName,
   actionVariant = 'light',
   allowDownloads = true,
@@ -107,7 +128,7 @@ export const PhotoCard: React.FC<PhotoCardProps> = ({
 }) => {
   const guestIdentity = useGuestIdentityOptional();
   const [overlayVisible, setOverlayVisible] = useState(false);
-  const [isTouchDevice, setIsTouchDevice] = useState(false);
+  const [isTouchDevice, setIsTouchDevice] = useState(detectCoarsePointer);
   const overlayTimeoutRef = useRef<number | null>(null);
 
   // Self-managed identity modal state (identityMode === 'self')
@@ -117,22 +138,12 @@ export const PhotoCard: React.FC<PhotoCardProps> = ({
 
   const savedIdentityValue = identityMode === 'self' ? selfIdentity : savedIdentity;
 
-  // Detect touch device (touch-aware overlay only)
+  // Keep the initial reading in step when the pointer changes under us —
+  // a tablet docked to a mouse, a browser window moved to another screen.
   useEffect(() => {
-    if (!touchAware || typeof window === 'undefined') return;
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
 
-    const mediaQuery = window.matchMedia('(hover: none) and (pointer: coarse)');
-    const updateTouchState = () => {
-      const hasNavigator = typeof navigator !== 'undefined';
-      setIsTouchDevice(
-        mediaQuery.matches ||
-        ('ontouchstart' in window) ||
-        (hasNavigator && navigator.maxTouchPoints > 0)
-      );
-    };
-
-    updateTouchState();
-
+    const mediaQuery = window.matchMedia(COARSE_POINTER_QUERY);
     const listener = (event: MediaQueryListEvent) => {
       setIsTouchDevice(event.matches);
     };
@@ -150,7 +161,7 @@ export const PhotoCard: React.FC<PhotoCardProps> = ({
         mediaQuery.removeListener(listener);
       }
     };
-  }, [touchAware]);
+  }, []);
 
   const hideOverlay = useCallback(() => {
     if (overlayTimeoutRef.current !== null && typeof window !== 'undefined') {
@@ -225,23 +236,22 @@ export const PhotoCard: React.FC<PhotoCardProps> = ({
 
   const showFeedbackActions = feedbackEnabled && Boolean(feedbackOptions);
 
-  const overlayVisibilityClass = overlayVisible
-    ? 'opacity-100 md:opacity-100'
-    : 'opacity-0 md:opacity-0';
+  // #1263 - opacity hides pixels, not hit-testing. An `opacity-0` control is
+  // still tappable, and on a touchscreen (no hover) it is invisible for good,
+  // so a tap in the middle of a tile silently downloaded or liked instead of
+  // opening the photo. Every visibility toggle below therefore moves
+  // pointer-events with it, in both the tap-to-reveal and the hover branch.
+  const revealed = (visible: boolean) =>
+    (visible
+      ? 'opacity-100 md:opacity-100 pointer-events-auto md:pointer-events-auto'
+      : 'opacity-0 md:opacity-0 pointer-events-none md:pointer-events-none')
+    + ' md:group-hover:opacity-100 md:group-hover:pointer-events-auto';
 
-  const overlayClassName = touchAware
-    ? `${overlayBaseClassName} ${overlayVisibilityClass} md:group-hover:opacity-100`
-    : overlayBaseClassName;
+  const overlayClassName = `${overlayBaseClassName} ${revealed(overlayVisible)}`;
 
-  const checkboxVisibilityClass = touchAware
-    ? `${
-        isSelected || isSelectionMode || overlayVisible
-          ? 'opacity-100 md:opacity-100'
-          : 'opacity-0 md:opacity-0'
-      } md:group-hover:opacity-100`
-    : isSelected
-      ? 'opacity-100'
-      : 'opacity-0 group-hover:opacity-100';
+  const checkboxVisibilityClass = revealed(
+    isSelected || isSelectionMode || overlayVisible,
+  );
 
   const buttonType = actionVariant === 'dark' ? ('button' as const) : undefined;
   const actionButtonClass =
@@ -251,11 +261,6 @@ export const PhotoCard: React.FC<PhotoCardProps> = ({
   const actionIconClass = actionVariant === 'dark' ? 'w-5 h-5 text-white' : 'w-5 h-5 text-neutral-800';
 
   const handlePhotoClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (!touchAware) {
-      onClick(e);
-      return;
-    }
-
     if (isTouchDevice && !overlayVisible && !isSelectionMode) {
       e.preventDefault();
       e.stopPropagation();

--- a/frontend/src/components/gallery/PhotoCard.tsx
+++ b/frontend/src/components/gallery/PhotoCard.tsx
@@ -17,16 +17,21 @@ const COARSE_POINTER_QUERY = '(hover: none) and (pointer: coarse)';
  * change here would land an extra render between the tile measurement in
  * useLayoutEffect and the image mount it gates, remounting each card once.
  *
- * matchMedia is missing in some test environments and old embedded webviews,
- * so the other two signals stand in for it.
+ * matchMedia is authoritative wherever it exists, because it describes the
+ * PRIMARY pointer. `ontouchstart` and `maxTouchPoints` only say a touchscreen
+ * is present somewhere, which is equally true of a touchscreen laptop being
+ * driven by its mouse -- OR-ing them in would classify that as touch-only and
+ * turn every ordinary click into a two-step reveal. They stand in only where
+ * matchMedia is absent (old embedded webviews, some test environments).
  */
 function detectCoarsePointer(): boolean {
   if (typeof window === 'undefined') return false;
+  if (typeof window.matchMedia === 'function') {
+    return window.matchMedia(COARSE_POINTER_QUERY).matches;
+  }
   const hasNavigator = typeof navigator !== 'undefined';
-  const fallback = ('ontouchstart' in window)
+  return ('ontouchstart' in window)
     || (hasNavigator && navigator.maxTouchPoints > 0);
-  if (typeof window.matchMedia !== 'function') return fallback;
-  return window.matchMedia(COARSE_POINTER_QUERY).matches || fallback;
 }
 
 export interface PhotoCardFeedbackOptions {
@@ -241,11 +246,22 @@ export const PhotoCard: React.FC<PhotoCardProps> = ({
   // so a tap in the middle of a tile silently downloaded or liked instead of
   // opening the photo. Every visibility toggle below therefore moves
   // pointer-events with it, in both the tap-to-reveal and the hover branch.
-  const revealed = (visible: boolean) =>
-    (visible
-      ? 'opacity-100 md:opacity-100 pointer-events-auto md:pointer-events-auto'
-      : 'opacity-0 md:opacity-0 pointer-events-none md:pointer-events-none')
-    + ' md:group-hover:opacity-100 md:group-hover:pointer-events-auto';
+  //
+  // The hover variants are emitted for pointer devices only, rather than being
+  // gated behind `md:`. Width is the wrong proxy for hover: a mouse user with
+  // a window under 768px got no overlay at all, and in Masonry, Mosaic and
+  // Timeline -- whose `group-hover:` used to be unprefixed -- that made
+  // download and like unreachable at any narrow width. Withholding the classes
+  // on touch is what the breakpoint was really for, since :hover latches on a
+  // touchscreen once a tile has been tapped.
+  const revealed = (visible: boolean) => {
+    const base = visible
+      ? 'opacity-100 pointer-events-auto'
+      : 'opacity-0 pointer-events-none';
+    return isTouchDevice
+      ? base
+      : `${base} group-hover:opacity-100 group-hover:pointer-events-auto`;
+  };
 
   const overlayClassName = `${overlayBaseClassName} ${revealed(overlayVisible)}`;
 

--- a/frontend/src/components/gallery/PhotoGrid.tsx
+++ b/frontend/src/components/gallery/PhotoGrid.tsx
@@ -311,8 +311,11 @@ const PhotoThumbnail: React.FC<PhotoThumbnailProps> = ({
             </div>
           )}
           
-          {/* Overlay on hover/tap - Always visible on mobile for better UX */}
-          <div className="absolute inset-0 bg-black/40 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity duration-200 rounded-lg flex items-center justify-center gap-2">
+          {/* Overlay on hover/tap - Always visible on mobile for better UX.
+              #1263: `md:opacity-0` hides the pixels but not the hit area, so
+              on a narrow pointer-device window the buttons stayed tappable
+              while invisible. pointer-events tracks opacity. */}
+          <div className="absolute inset-0 bg-black/40 opacity-100 pointer-events-auto md:opacity-0 md:pointer-events-none md:group-hover:opacity-100 md:group-hover:pointer-events-auto transition-opacity duration-200 rounded-lg flex items-center justify-center gap-2">
             {!isSelectionMode && (
               <>
                 <button
@@ -328,7 +331,12 @@ const PhotoThumbnail: React.FC<PhotoThumbnailProps> = ({
                 {allowDownloads && (
                   <button
                     className="p-2 sm:p-2 bg-white/90 rounded-full hover:bg-white transition-colors"
-                    onClick={onDownload}
+                    // #1263 — without stopPropagation the tap also reached the
+                    // tile's own onClick, so downloading opened the lightbox too.
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onDownload(e);
+                    }}
                     aria-label="Download photo"
                   >
                     <Download className="w-5 h-5 text-theme" />

--- a/frontend/src/components/gallery/__tests__/PhotoCard.touchTargets.test.tsx
+++ b/frontend/src/components/gallery/__tests__/PhotoCard.touchTargets.test.tsx
@@ -168,6 +168,46 @@ describe('PhotoCard overlay hit-testing (#1263)', () => {
 
     fireEvent.click(container.querySelector('.tile')!);
     expect(onClick).toHaveBeenCalledTimes(1);
-    expect(tokens(overlayOf(container))).toContain('md:group-hover:pointer-events-auto');
+    expect(tokens(overlayOf(container))).toContain('group-hover:pointer-events-auto');
+  });
+
+  it('reaches the hover overlay below the md breakpoint', () => {
+    // Codex review round 1. The hover variants used to be `md:group-hover:*`,
+    // so a mouse user with a window under 768px saw no overlay at all — and in
+    // Masonry, Mosaic and Timeline, whose `group-hover:` was unprefixed before
+    // this branch, that made download and like unreachable. Viewport width is
+    // not what decides whether a device can hover.
+    stubTouchDevice(false);
+    const { container } = renderCard();
+    const overlay = tokens(overlayOf(container));
+
+    expect(overlay).toContain('group-hover:opacity-100');
+    expect(overlay).toContain('group-hover:pointer-events-auto');
+    expect(overlay.some((c) => c.startsWith('md:'))).toBe(false);
+  });
+
+  it('withholds the hover variants on touch, where :hover latches after a tap', () => {
+    // The reason the breakpoint was there in the first place. Emitting
+    // `group-hover:` on a touchscreen leaves the overlay stuck open on the
+    // last tile tapped.
+    const { container } = renderCard();
+    expect(tokens(overlayOf(container)).some((c) => c.startsWith('group-hover:'))).toBe(false);
+  });
+
+  it('treats a touchscreen laptop driven by a mouse as a pointer device', () => {
+    // Codex review round 1. matchMedia describes the PRIMARY pointer;
+    // maxTouchPoints only says a touchscreen exists. OR-ing them classified a
+    // hybrid device as touch-only, so an ordinary click merely revealed the
+    // overlay and opening a photo took two clicks — a regression for the three
+    // layouts that had no tap-to-reveal step before.
+    stubTouchDevice(false);
+    Object.defineProperty(navigator, 'maxTouchPoints', { configurable: true, value: 10 });
+    (window as any).ontouchstart = null;
+
+    const onClick = vi.fn();
+    const { container } = renderCard({ onClick });
+
+    fireEvent.click(container.querySelector('.tile')!);
+    expect(onClick).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/components/gallery/__tests__/PhotoCard.touchTargets.test.tsx
+++ b/frontend/src/components/gallery/__tests__/PhotoCard.touchTargets.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * Mobile tap determinism (#1263).
+ *
+ * The overlay actions (open / download / like) are hidden with `opacity-0`,
+ * which hides pixels but not hit-testing. On a pointer device hover reveals
+ * them before anyone can click, so the gap never shows; on a touchscreen there
+ * is no hover, so the buttons stayed permanently invisible AND permanently
+ * tappable. A tap near the middle of a tile hit an unseen button, whose
+ * stopPropagation then suppressed the tile's own open — so the same gesture
+ * downloaded, liked or opened depending on where the finger landed.
+ *
+ * Visibility and hit-testing have to move together. These tests pin the
+ * pointer-events half, which is the half that was missing.
+ */
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { PhotoCard } from '../PhotoCard';
+import type { Photo } from '../../../types';
+
+vi.mock('../../common', () => ({
+  AuthenticatedImage: ({ src, alt }: { src: string; alt?: string }) => (
+    <img data-testid="tile" src={src} alt={alt} />
+  ),
+}));
+
+vi.mock('../../../contexts/GuestIdentityContext', () => ({
+  useGuestIdentityOptional: () => null,
+}));
+
+const PHOTO = {
+  id: 7,
+  filename: 'IMG_0001.jpg',
+  url: '/api/gallery/x/photo/7',
+  thumbnail_url: '/api/gallery/x/thumbnail/7',
+  type: 'individual',
+  size: 1,
+  uploaded_at: '2026-01-01T00:00:00Z',
+  width: 4000,
+  height: 3000,
+} as Photo;
+
+/** Report a coarse, hover-less pointer — a phone. */
+function stubTouchDevice(isTouch: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches: isTouch && query.includes('pointer: coarse'),
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      onchange: null,
+      dispatchEvent: () => false,
+    }),
+  });
+  Object.defineProperty(navigator, 'maxTouchPoints', {
+    configurable: true,
+    value: isTouch ? 5 : 0,
+  });
+  // jsdom defines `ontouchstart`, which PhotoCard reads as a third touch
+  // signal — remove it so the pointer-device case is actually exercised.
+  if (isTouch) (window as any).ontouchstart = null;
+  else delete (window as any).ontouchstart;
+}
+
+/** Class tokens, so `md:group-hover:pointer-events-auto` isn't mistaken for the bare one. */
+function tokens(el: HTMLElement) {
+  return Array.from(el.classList);
+}
+
+function renderCard(props: Partial<React.ComponentProps<typeof PhotoCard>> = {}) {
+  return render(
+    <PhotoCard
+      photo={PHOTO}
+      isSelected={false}
+      isSelectionMode={false}
+      onClick={() => {}}
+      onDownload={() => {}}
+      onToggleSelect={() => {}}
+      className="group tile"
+      overlayBaseClassName="absolute inset-0 flex items-center justify-center gap-2"
+      imageProps={{ src: PHOTO.thumbnail_url!, alt: PHOTO.filename }}
+      allowDownloads
+      {...props}
+    />,
+  );
+}
+
+/** The overlay is the element the action buttons live in. */
+function overlayOf(container: HTMLElement) {
+  const button = container.querySelector('[aria-label="View full size"]');
+  return button?.parentElement as HTMLElement;
+}
+
+beforeEach(() => {
+  Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+    configurable: true,
+    get() { return 320; },
+  });
+  stubTouchDevice(true);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete (HTMLElement.prototype as any).offsetWidth;
+});
+
+describe('PhotoCard overlay hit-testing (#1263)', () => {
+  it('makes the hidden overlay inert, so a tap cannot reach an unseen button', () => {
+    const { container } = renderCard();
+    const overlay = overlayOf(container);
+
+    expect(tokens(overlay)).toContain('opacity-0');
+    expect(tokens(overlay)).toContain('pointer-events-none');
+    expect(tokens(overlay)).not.toContain('pointer-events-auto');
+  });
+
+  it('arms the overlay once a tap has revealed it', () => {
+    const onClick = vi.fn();
+    const { container } = renderCard({ onClick });
+
+    // First tap on the tile body reveals the actions; it must not open.
+    fireEvent.click(container.querySelector('.tile')!);
+    expect(onClick).not.toHaveBeenCalled();
+
+    const overlay = overlayOf(container);
+    expect(tokens(overlay)).toContain('opacity-100');
+    expect(tokens(overlay)).toContain('pointer-events-auto');
+    expect(tokens(overlay)).not.toContain('pointer-events-none');
+
+    // Second tap on the tile body now opens the photo.
+    fireEvent.click(container.querySelector('.tile')!);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the selection checkbox inert while it is invisible', () => {
+    const onToggleSelect = vi.fn();
+    const { container } = renderCard({ onToggleSelect });
+    const checkbox = screen.getByRole('checkbox');
+
+    expect(tokens(checkbox)).toContain('opacity-0');
+    expect(tokens(checkbox)).toContain('pointer-events-none');
+
+    fireEvent.click(container.querySelector('.tile')!);
+    expect(tokens(screen.getByRole('checkbox'))).toContain('pointer-events-auto');
+  });
+
+  it('reveals on touch without a layout having to opt in', () => {
+    // Masonry / Mosaic / Timeline previously passed their own
+    // `opacity-0 group-hover:opacity-100` and never opted into the touch
+    // state machine, so on a phone their overlay was unreachable-but-tappable
+    // forever. PhotoCard owns visibility for every layout now.
+    const onClick = vi.fn();
+    const { container } = renderCard({ onClick });
+    fireEvent.click(container.querySelector('.tile')!);
+    expect(onClick).not.toHaveBeenCalled();
+    expect(tokens(overlayOf(container))).toContain('pointer-events-auto');
+  });
+
+  it('leaves a pointer device on hover semantics — no tap-to-reveal step', () => {
+    stubTouchDevice(false);
+    const onClick = vi.fn();
+    const { container } = renderCard({ onClick });
+
+    fireEvent.click(container.querySelector('.tile')!);
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(tokens(overlayOf(container))).toContain('md:group-hover:pointer-events-auto');
+  });
+});

--- a/frontend/src/components/gallery/layouts/GalleryPremiumLayout.css
+++ b/frontend/src/components/gallery/layouts/GalleryPremiumLayout.css
@@ -292,11 +292,16 @@
   transition: all 0.2s ease;
   cursor: pointer;
   opacity: 0;
+  /* #1263 - opacity 0 still hit-tests. On a touchscreen there is no hover to
+     reveal this, so the top-left corner of every tile silently toggled
+     selection. Hit-testing tracks visibility. */
+  pointer-events: none;
 }
 
 .gallery-premium-photo-card:hover .gallery-premium-checkbox,
 .gallery-premium-checkbox.visible {
   opacity: 1;
+  pointer-events: auto;
 }
 
 .gallery-premium-checkbox:hover {
@@ -323,11 +328,35 @@
   cursor: pointer;
   transition: all 0.2s ease;
   opacity: 0;
+  /* #1263 - same as the checkbox: invisible must also mean untappable, or the
+     top-right corner of every tile likes the photo instead of opening it. */
+  pointer-events: none;
 }
 
 .gallery-premium-photo-card:hover .gallery-premium-like-btn,
 .gallery-premium-like-btn.liked {
   opacity: 1;
+  pointer-events: auto;
+}
+
+/* Touch devices never get :hover, so the two controls above would be
+   permanently unreachable rather than merely accidental. Show them outright
+   and give them a finger-sized target (#1263). */
+@media (hover: none) and (pointer: coarse) {
+  .gallery-premium-checkbox,
+  .gallery-premium-like-btn {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .gallery-premium-checkbox {
+    height: 2.25rem;
+    width: 2.25rem;
+  }
+
+  .gallery-premium-like-btn {
+    padding: 0.75rem;
+  }
 }
 
 .gallery-premium-like-btn:hover {

--- a/frontend/src/components/gallery/layouts/GridGalleryLayout.tsx
+++ b/frontend/src/components/gallery/layouts/GridGalleryLayout.tsx
@@ -86,7 +86,6 @@ const GridPhoto: React.FC<GridPhotoProps> = ({
       lazy
       fadeInWhenVisible={animationType === 'fade'}
       skeletonClassName="skeleton aspect-square w-full rounded-lg"
-      touchAware
       imageProps={{
         src: photo.thumbnail_url || photo.url,
         alt: photo.filename,

--- a/frontend/src/components/gallery/layouts/JustifiedGalleryLayout.tsx
+++ b/frontend/src/components/gallery/layouts/JustifiedGalleryLayout.tsx
@@ -127,7 +127,6 @@ const JustifiedPhoto: React.FC<JustifiedPhotoProps> = ({
       inViewRootMargin="100px"
       fadeInWhenVisible={animationType === 'fade'}
       skeletonClassName="skeleton w-full h-full rounded-lg"
-      touchAware
       imageProps={{
         src: photo.thumbnail_url || photo.url,
         alt: photo.filename,

--- a/frontend/src/components/gallery/layouts/MasonryGalleryLayout.tsx
+++ b/frontend/src/components/gallery/layouts/MasonryGalleryLayout.tsx
@@ -122,7 +122,7 @@ const MasonryPhoto: React.FC<MasonryPhotoProps> = ({
         isGallery: true,
         protectFromDownload: !allowDownloads,
       }}
-      overlayBaseClassName="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity duration-200 rounded-lg flex items-center justify-center gap-2"
+      overlayBaseClassName="absolute inset-0 bg-black/40 transition-opacity duration-200 rounded-lg flex items-center justify-center gap-2"
       allowDownloads={allowDownloads}
       feedbackEnabled={feedbackEnabled}
       feedbackOptions={feedbackOptions}
@@ -378,7 +378,7 @@ export const MasonryGalleryLayout: React.FC<BaseGalleryLayoutProps> = ({
                 isGallery: true,
                 protectFromDownload: !allowDownloads,
               }}
-              overlayBaseClassName="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity duration-200 rounded-lg flex items-center justify-center gap-2"
+              overlayBaseClassName="absolute inset-0 bg-black/40 transition-opacity duration-200 rounded-lg flex items-center justify-center gap-2"
               actionVariant="dark"
               allowDownloads={allowDownloads}
               beforeOverlay={feedbackEnabled ? <FeedbackCountIndicators photo={photo} /> : undefined}
@@ -436,7 +436,7 @@ export const MasonryGalleryLayout: React.FC<BaseGalleryLayoutProps> = ({
                 isGallery: true,
                 protectFromDownload: !allowDownloads,
               }}
-              overlayBaseClassName="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity duration-200 rounded-lg flex items-center justify-center gap-2"
+              overlayBaseClassName="absolute inset-0 bg-black/40 transition-opacity duration-200 rounded-lg flex items-center justify-center gap-2"
               actionVariant="dark"
               allowDownloads={allowDownloads}
               beforeOverlay={feedbackEnabled ? <FeedbackCountIndicators photo={photo} /> : undefined}
@@ -503,7 +503,7 @@ export const MasonryGalleryLayout: React.FC<BaseGalleryLayoutProps> = ({
                 isGallery: true,
                 protectFromDownload: !allowDownloads,
               }}
-              overlayBaseClassName="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity duration-200 flex items-center justify-center gap-2"
+              overlayBaseClassName="absolute inset-0 bg-black/40 transition-opacity duration-200 flex items-center justify-center gap-2"
               actionVariant="dark"
               allowDownloads={allowDownloads}
               beforeOverlay={feedbackEnabled ? <FeedbackCountIndicators photo={photo} /> : undefined}

--- a/frontend/src/components/gallery/layouts/MosaicGalleryLayout.tsx
+++ b/frontend/src/components/gallery/layouts/MosaicGalleryLayout.tsx
@@ -85,7 +85,7 @@ const MosaicPhoto: React.FC<MosaicPhotoProps> = ({
           isGallery: true,
           protectFromDownload: !allowDownloads,
         }}
-        overlayBaseClassName="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity duration-200 flex items-center justify-center gap-2"
+        overlayBaseClassName="absolute inset-0 bg-black/40 transition-opacity duration-200 flex items-center justify-center gap-2"
         allowDownloads={allowDownloads}
         feedbackEnabled={feedbackEnabled}
         feedbackOptions={feedbackOptions}

--- a/frontend/src/components/gallery/layouts/TimelineGalleryLayout.tsx
+++ b/frontend/src/components/gallery/layouts/TimelineGalleryLayout.tsx
@@ -132,7 +132,7 @@ export const TimelineGalleryLayout: React.FC<BaseGalleryLayoutProps> = ({
                       isGallery: true,
                       protectFromDownload: !allowDownloads,
                     }}
-                    overlayBaseClassName="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity duration-200 rounded-lg flex items-center justify-center gap-2"
+                    overlayBaseClassName="absolute inset-0 bg-black/40 transition-opacity duration-200 rounded-lg flex items-center justify-center gap-2"
                     allowDownloads={allowDownloads}
                     feedbackEnabled={feedbackEnabled}
                     feedbackOptions={feedbackOptions}


### PR DESCRIPTION
Closes #1263.

## Root cause

`opacity-0` hides pixels, not hit-testing. The overlay's View/Download/Like buttons and the selection checkbox were rendered at opacity 0 and left fully tappable, and each one calls `stopPropagation` — so a finger landing on an unseen button both fired that action and suppressed the tile's own open. That is the "je nach Tap-Position öffnen / downloaden / liken" exactly.

On a pointer device hover reveals the controls before anyone can click them, so the gap never showed. On a touchscreen there is no hover, so in Masonry, Mosaic and Timeline the controls were invisible for good and tappable for good.

## Reproduced

Local rig, 390×844, real CDP touch emulation (`Emulation.setEmulatedMedia` hover:none / pointer:coarse + `setTouchEmulationEnabled`), probing with `elementFromPoint` at the tile centre and tapping via `Input.dispatchTouchEvent`:

| | idle hit at tile centre | one tap on the tile |
| --- | --- | --- |
| `main` | `BUTTON Download photo` | file downloaded, no lightbox |
| this branch | `IMG` | overlay revealed, 0 downloads |

## Fix

`PhotoCard` owns visibility and hit-testing for every layout, instead of each layout passing its own opacity classes:

- **`touchAware` is gone.** It gated the tap-to-reveal state machine and only `GridGalleryLayout` and `JustifiedGalleryLayout` opted in — which is precisely why those two behaved and Masonry / Mosaic / Timeline did not. Every PhotoCard layout is touch-aware now: first tap reveals, second tap on a control acts, second tap elsewhere opens. Pointer devices keep hover semantics unchanged.
- **pointer-events tracks opacity** in both the tap-to-reveal and the hover branch, for the overlay and for the checkbox.
- **The pointer reading moved from an effect into the initial state.** As an effect it landed a mount-time render between the tile measurement in `useLayoutEffect` and the image mount that measurement gates, remounting every card once — caught by the #1095 regression test, which is the reason that test exists. It also degrades to `ontouchstart` / `maxTouchPoints` where `matchMedia` is absent, since every layout runs this path now.

Two more instances of the same class outside `PhotoCard`:

- `GalleryPremiumLayout.css` — the checkbox and like button are CSS-hidden the same way. They get `pointer-events` alongside `opacity`, and since that layout has no reveal gesture, a `(hover: none)` block shows both outright at a finger-sized target rather than leaving them unreachable.
- `PhotoGrid.tsx:331` — the download button called `onClick={onDownload}` with no `stopPropagation`, so downloading also opened the lightbox. (Component is currently only exported from the barrel, not mounted, but it's the same defect and a one-liner.)

## Screenshots

Mobile viewport, touch emulation on, same tile and same tap coordinates in both.

**Before — one tap downloads the photo:**

![before](https://raw.githubusercontent.com/PicPeak/picpeak/screenshots/queue-invite-taps-1261-1263/1263-before-2-after-tap.png)

**After — the same tap reveals the controls instead:**

![after](https://raw.githubusercontent.com/PicPeak/picpeak/screenshots/queue-invite-taps-1261-1263/1263-after-2-tap-reveals.png)

## Tests

`frontend/src/components/gallery/__tests__/PhotoCard.touchTargets.test.tsx` — 5 tests, all 5 failing against the old implementation. Full frontend suite green (453 passed).

## Worth a decision

On touch, opening a photo is now two taps: reveal, then open. That's the pre-existing Grid / Justified model applied uniformly, and it satisfies "an action never also opens" — but it isn't literally "ein normaler Tap öffnet das Foto". Moving Like/Download into the lightbox only, so the first tap always opens, is a separate design call I've deliberately left out of this PR.



---

## Review rounds

Two rounds of external review (Codex).

**Round 1** — two findings, both valid, both consequences of extending the Grid/Justified tap-to-reveal model to every layout:
- The hover variants were behind `md:`, so a **mouse user with a window under 768px** got no overlay at all. Grid and Justified already behaved that way, but Masonry, Mosaic and Timeline had unprefixed `group-hover:` and revealed at any width — a regression for those three. Width was never the real question: the breakpoint was standing in for "`:hover` latches on a touchscreen once a tile is tapped", so the variants are now emitted for pointer devices and withheld on touch, which says that directly.
- `detectCoarsePointer` OR-ed the touch fallbacks over `matchMedia`. `matchMedia` describes the *primary* pointer; `maxTouchPoints` only says a touchscreen exists somewhere, which is equally true of a **touchscreen laptop driven by its mouse** — so an ordinary click merely revealed the overlay and opening a photo took two clicks. The fallbacks now stand in only where `matchMedia` is absent, which is what the comment already claimed.

**Round 2** — one finding, deferred, and flagged here rather than fixed:

On a hybrid device the media query describes the primary pointer, not the pointer producing the current interaction. So a finger tap on a fine-primary touchscreen laptop is handled as a mouse click (opens immediately, no tap-to-reveal), and a mouse click on a coarse-primary tablet still takes two clicks. I asked Codex to separate severity from polish, and it confirmed: **the original #1263 defect — a finger landing on an invisible-but-tappable Download/Like — does not recur on any hybrid**, because the hidden controls carry `pointer-events-none`. What remains is an interaction-quality gap.

Closing it properly means classifying pointer mode per interaction across `pointerenter`/`pointermove`/`pointerdown`, and giving `GalleryPremiumLayout.css`'s static `:hover` rules and `(hover: none)` block equivalent dynamic gating — a state machine spanning two components. That is a design change beyond this bug, so it is tracked separately as #1275 rather than bolted on here.

The tempting half-measure — updating the mode on `pointerdown` only — was considered and rejected: it makes a tile behave differently depending on what you touched last, which is the same class of nondeterminism this PR exists to remove.

**Verification:** frontend 459 passed, typecheck clean, lint clean (2 pre-existing warnings in an untouched file).

