### PR TITLE
fix(crm): tell the admin whether a customer's invitation actually went out (#1261)

### DIFF
--- a/backend/src/services/customerAccountsService.js
+++ b/backend/src/services/customerAccountsService.js
@@ -126,7 +126,16 @@ async function createInvitation({ email, invitedById, prefill }) {
     .first();
   if (existingCustomer && existingCustomer.password_hash) {
     // Already-active customer with this email — duplicate, reject.
-    throw new ConflictError('A customer account with this email already exists', 'email');
+    //
+    // Carries the same code the send-invite route uses for its own
+    // already-active check (#1261). Both conflicts are 409 and both can mean
+    // "this address already has portal access" — the route reads the customer
+    // before this recheck runs, so an invitation accepted in between lands
+    // here instead — and a caller that cannot tell the two apart ends up
+    // telling the admin to cancel an invitation acceptance already closed.
+    const err = new ConflictError('A customer account with this email already exists', 'email');
+    err.code = 'CUSTOMER_ALREADY_ACTIVE';
+    throw err;
   }
   // If the existing customer is PASSIVE (password_hash IS NULL), this
   // is the "promote to active" path: the admin clicked "Send portal
@@ -139,7 +148,9 @@ async function createInvitation({ email, invitedById, prefill }) {
     .where('expires_at', '>', new Date())
     .first();
   if (pendingInvite) {
-    throw new ConflictError('A pending invitation already exists for this email', 'email');
+    const err = new ConflictError('A pending invitation already exists for this email', 'email');
+    err.code = 'INVITATION_ALREADY_PENDING';
+    throw err;
   }
 
   // 64-char hex = 32 bytes = 256 bits of entropy. Same as admin invites.

--- a/frontend/src/components/admin/InlineCustomerCreate.tsx
+++ b/frontend/src/components/admin/InlineCustomerCreate.tsx
@@ -189,15 +189,34 @@ export const InlineCustomerCreate: React.FC<Props> = ({ onCreated, onCancel, mod
           toast.success(t('customers.create.savedActiveToast',
             'Customer created and portal invitation queued. It is sent by the email queue — check System health if it does not arrive.'));
         } catch (err: any) {
-          // A 409 means an invitation for this address is already open, which
-          // is a different thing from the email failing: the customer is
-          // invited, and re-inviting is what was refused.
-          const alreadyInvited = err?.response?.status === 409;
-          toast.warn(alreadyInvited
-            ? t('customers.create.inviteAlreadyPendingToast',
-              'Customer saved. An invitation for this address is already open — cancel it on the Invitations tab before sending a new one.')
-            : t('customers.create.inviteFailedToast',
+          // Three different things reach this branch and they need three
+          // different answers. Only one of them means "no invitation exists".
+          const status = err?.response?.status;
+          const code = err?.response?.data?.code;
+
+          if (status === 409 && code === 'CUSTOMER_ALREADY_ACTIVE') {
+            // An open invitation for this address was accepted between
+            // createDirect and sendInvite. The customer has portal access
+            // already, so there is nothing to cancel and nothing to resend.
+            toast.info(t('customers.create.inviteAlreadyActiveToast',
+              'Customer saved. This address already has portal access, so no invitation was needed.'));
+          } else if (status === 409) {
+            // An invitation for this address is already open and the RE-invite
+            // was refused. The customer IS invited; telling them to retry
+            // would send them the wrong way.
+            toast.warn(t('customers.create.inviteAlreadyPendingToast',
+              'Customer saved. An invitation for this address is already open — cancel it on the Invitations tab before sending a new one.'));
+          } else if (!err?.response) {
+            // No response at all: a dropped connection or a timeout. The
+            // request may well have succeeded server-side, so claiming it
+            // failed sends the admin into a retry that then 409s. Say what is
+            // actually known and point at where the answer is.
+            toast.warn(t('customers.create.inviteUnconfirmedToast',
+              'Customer saved, but the invitation could not be confirmed — the server did not answer. Check the Invitations tab before sending another.'));
+          } else {
+            toast.warn(t('customers.create.inviteFailedToast',
               'Customer saved as PASSIVE — no invitation went out. Retry "Send portal invitation" from the customer detail page.'));
+          }
           // eslint-disable-next-line no-console
           console.warn('sendInvite failed', err);
         }

--- a/frontend/src/components/admin/InlineCustomerCreate.tsx
+++ b/frontend/src/components/admin/InlineCustomerCreate.tsx
@@ -189,31 +189,36 @@ export const InlineCustomerCreate: React.FC<Props> = ({ onCreated, onCancel, mod
           toast.success(t('customers.create.savedActiveToast',
             'Customer created and portal invitation queued. It is sent by the email queue — check System health if it does not arrive.'));
         } catch (err: any) {
-          // Three different things reach this branch and they need three
-          // different answers. Only one of them means "no invitation exists".
+          // Four different things reach this branch and they need four
+          // different answers. Only ONE of them means "nothing happened, go
+          // ahead and retry" — every other message that says so sends the
+          // admin into a retry that then 409s.
           const status = err?.response?.status;
           const code = err?.response?.data?.code;
 
-          if (status === 409 && code === 'CUSTOMER_ALREADY_ACTIVE') {
-            // An open invitation for this address was accepted between
-            // createDirect and sendInvite. The customer has portal access
-            // already, so there is nothing to cancel and nothing to resend.
+          if (code === 'CUSTOMER_ALREADY_ACTIVE') {
+            // This address already has portal access — either the route's own
+            // check, or an invitation accepted between it and the service's
+            // recheck. Nothing to cancel, nothing to resend.
             toast.info(t('customers.create.inviteAlreadyActiveToast',
               'Customer saved. This address already has portal access, so no invitation was needed.'));
           } else if (status === 409) {
             // An invitation for this address is already open and the RE-invite
-            // was refused. The customer IS invited; telling them to retry
-            // would send them the wrong way.
+            // was refused. The customer IS invited.
             toast.warn(t('customers.create.inviteAlreadyPendingToast',
               'Customer saved. An invitation for this address is already open — cancel it on the Invitations tab before sending a new one.'));
-          } else if (!err?.response) {
-            // No response at all: a dropped connection or a timeout. The
-            // request may well have succeeded server-side, so claiming it
-            // failed sends the admin into a retry that then 409s. Say what is
-            // actually known and point at where the answer is.
+          } else if (!err?.response || status >= 500) {
+            // No response (dropped connection, timeout) or a server error.
+            // Neither says the invitation was not created: createInvitation
+            // inserts the customer_invitations row and only then queues the
+            // email, without a transaction, so a 500 out of the queueing step
+            // leaves an open invitation behind. Asserting a clean failure here
+            // sends the admin into a retry that 409s and still queues nothing.
             toast.warn(t('customers.create.inviteUnconfirmedToast',
-              'Customer saved, but the invitation could not be confirmed — the server did not answer. Check the Invitations tab before sending another.'));
+              'Customer saved, but the invitation could not be confirmed — check the Invitations tab before sending another.'));
           } else {
+            // A 4xx that is not a conflict: validation, permissions, no such
+            // customer. The request was rejected before anything was written.
             toast.warn(t('customers.create.inviteFailedToast',
               'Customer saved as PASSIVE — no invitation went out. Retry "Send portal invitation" from the customer detail page.'));
           }

--- a/frontend/src/components/admin/InlineCustomerCreate.tsx
+++ b/frontend/src/components/admin/InlineCustomerCreate.tsx
@@ -16,6 +16,11 @@
  * stays saved (passive) and a warning toast asks the admin to retry
  * from the customer detail page.
  *
+ * #1261 — the toasts here say what actually happened rather than what was
+ * intended. Two calls means three outcomes, and the middle one used to be
+ * indistinguishable from success: the invitation email is only QUEUED, so
+ * "invitation sent" was a claim this code cannot make.
+ *
  * Field set mirrors the customer detail page so admins see the same
  * shape regardless of where they're editing.
  */
@@ -182,10 +187,17 @@ export const InlineCustomerCreate: React.FC<Props> = ({ onCreated, onCancel, mod
         try {
           await customerAdminService.sendInvite(customer.id);
           toast.success(t('customers.create.savedActiveToast',
-            'Customer created and portal invitation sent.'));
+            'Customer created and portal invitation queued. It is sent by the email queue — check System health if it does not arrive.'));
         } catch (err: any) {
-          toast.warn(t('customers.create.inviteFailedToast',
-            'Customer saved (passive). Invitation email failed — retry from the customer detail page.'));
+          // A 409 means an invitation for this address is already open, which
+          // is a different thing from the email failing: the customer is
+          // invited, and re-inviting is what was refused.
+          const alreadyInvited = err?.response?.status === 409;
+          toast.warn(alreadyInvited
+            ? t('customers.create.inviteAlreadyPendingToast',
+              'Customer saved. An invitation for this address is already open — cancel it on the Invitations tab before sending a new one.')
+            : t('customers.create.inviteFailedToast',
+              'Customer saved as PASSIVE — no invitation went out. Retry "Send portal invitation" from the customer detail page.'));
           // eslint-disable-next-line no-console
           console.warn('sendInvite failed', err);
         }

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -4854,7 +4854,7 @@
       "nameRequired": "Geben Sie mindestens einen Firmennamen oder einen Ansprechpartner an.",
       "inviteAlreadyPendingToast": "Kunde gespeichert. Für diese Adresse ist bereits eine Einladung offen — stornieren Sie sie im Tab „Einladungen“, bevor Sie eine neue senden.",
       "inviteAlreadyActiveToast": "Kunde gespeichert. Diese Adresse hat bereits Portalzugang, eine Einladung war nicht nötig.",
-      "inviteUnconfirmedToast": "Kunde gespeichert, aber die Einladung ist unbestätigt — der Server hat nicht geantwortet. Prüfen Sie den Tab „Einladungen“, bevor Sie erneut senden."
+      "inviteUnconfirmedToast": "Kunde gespeichert, aber die Einladung ist unbestätigt — prüfen Sie den Tab „Einladungen“, bevor Sie erneut senden."
     },
     "passive": {
       "badge": "Passiv — nur Admin",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -4848,10 +4848,11 @@
       "saveAsPassive": "Als passiven Kunden speichern",
       "saveAndInvite": "Speichern & Portal-Einladung senden",
       "savedPassiveToast": "Passiver Kunde erstellt.",
-      "savedActiveToast": "Kunde erstellt und Portal-Einladung gesendet.",
-      "inviteFailedToast": "Kunde gespeichert (passiv). Einladungs-E-Mail fehlgeschlagen — bitte aus dem Kundendetail erneut versuchen.",
+      "savedActiveToast": "Kunde angelegt und Portal-Einladung eingereiht. Der Versand läuft über die E-Mail-Warteschlange — prüfen Sie den Systemzustand, falls sie nicht ankommt.",
+      "inviteFailedToast": "Kunde als PASSIV gespeichert — es ging keine Einladung raus. Wiederholen Sie „Portal-Einladung senden“ auf der Kundendetailseite.",
       "emailRequired": "Eine gültige E-Mail-Adresse ist erforderlich.",
-      "nameRequired": "Geben Sie mindestens einen Firmennamen oder einen Ansprechpartner an."
+      "nameRequired": "Geben Sie mindestens einen Firmennamen oder einen Ansprechpartner an.",
+      "inviteAlreadyPendingToast": "Kunde gespeichert. Für diese Adresse ist bereits eine Einladung offen — stornieren Sie sie im Tab „Einladungen“, bevor Sie eine neue senden."
     },
     "passive": {
       "badge": "Passiv — nur Admin",
@@ -5045,6 +5046,10 @@
       "addedN_other": "{{count}} hinzugefügt",
       "removedN_one": "{{count}} entfernt",
       "removedN_other": "{{count}} entfernt"
+    },
+    "invitePending": {
+      "badge": "Einladung offen",
+      "hint": "Einladung verschickt, noch nicht angenommen. Der Kunde bleibt passiv, bis er ein Passwort gesetzt hat."
     }
   },
   "clients": {

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -4852,7 +4852,9 @@
       "inviteFailedToast": "Kunde als PASSIV gespeichert — es ging keine Einladung raus. Wiederholen Sie „Portal-Einladung senden“ auf der Kundendetailseite.",
       "emailRequired": "Eine gültige E-Mail-Adresse ist erforderlich.",
       "nameRequired": "Geben Sie mindestens einen Firmennamen oder einen Ansprechpartner an.",
-      "inviteAlreadyPendingToast": "Kunde gespeichert. Für diese Adresse ist bereits eine Einladung offen — stornieren Sie sie im Tab „Einladungen“, bevor Sie eine neue senden."
+      "inviteAlreadyPendingToast": "Kunde gespeichert. Für diese Adresse ist bereits eine Einladung offen — stornieren Sie sie im Tab „Einladungen“, bevor Sie eine neue senden.",
+      "inviteAlreadyActiveToast": "Kunde gespeichert. Diese Adresse hat bereits Portalzugang, eine Einladung war nicht nötig.",
+      "inviteUnconfirmedToast": "Kunde gespeichert, aber die Einladung ist unbestätigt — der Server hat nicht geantwortet. Prüfen Sie den Tab „Einladungen“, bevor Sie erneut senden."
     },
     "passive": {
       "badge": "Passiv — nur Admin",
@@ -5049,7 +5051,7 @@
     },
     "invitePending": {
       "badge": "Einladung offen",
-      "hint": "Einladung verschickt, noch nicht angenommen. Der Kunde bleibt passiv, bis er ein Passwort gesetzt hat."
+      "hint": "Für diese Adresse ist ein Einladungslink offen und noch nicht angenommen. Das ist kein Beleg dafür, dass die E-Mail angekommen ist — prüfen Sie den Systemzustand, falls der Kunde nichts erhalten hat."
     }
   },
   "clients": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -4848,10 +4848,11 @@
       "saveAsPassive": "Save as passive customer",
       "saveAndInvite": "Save & send portal invitation",
       "savedPassiveToast": "Passive customer created.",
-      "savedActiveToast": "Customer created and portal invitation sent.",
-      "inviteFailedToast": "Customer saved (passive). Invitation email failed — retry from the customer detail page.",
+      "savedActiveToast": "Customer created and portal invitation queued. It is sent by the email queue — check System health if it does not arrive.",
+      "inviteFailedToast": "Customer saved as PASSIVE — no invitation went out. Retry \"Send portal invitation\" from the customer detail page.",
       "emailRequired": "A valid email is required.",
-      "nameRequired": "Enter at least a company name or a contact name."
+      "nameRequired": "Enter at least a company name or a contact name.",
+      "inviteAlreadyPendingToast": "Customer saved. An invitation for this address is already open — cancel it on the Invitations tab before sending a new one."
     },
     "passive": {
       "badge": "Passive — admin only",
@@ -5045,6 +5046,10 @@
       "addedN_other": "{{count}} added",
       "removedN_one": "{{count}} removed",
       "removedN_other": "{{count}} removed"
+    },
+    "invitePending": {
+      "badge": "Invitation pending",
+      "hint": "Invitation sent, not accepted yet. The customer stays passive until they set a password."
     }
   },
   "clients": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -4854,7 +4854,7 @@
       "nameRequired": "Enter at least a company name or a contact name.",
       "inviteAlreadyPendingToast": "Customer saved. An invitation for this address is already open — cancel it on the Invitations tab before sending a new one.",
       "inviteAlreadyActiveToast": "Customer saved. This address already has portal access, so no invitation was needed.",
-      "inviteUnconfirmedToast": "Customer saved, but the invitation could not be confirmed — the server did not answer. Check the Invitations tab before sending another."
+      "inviteUnconfirmedToast": "Customer saved, but the invitation could not be confirmed — check the Invitations tab before sending another."
     },
     "passive": {
       "badge": "Passive — admin only",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -4852,7 +4852,9 @@
       "inviteFailedToast": "Customer saved as PASSIVE — no invitation went out. Retry \"Send portal invitation\" from the customer detail page.",
       "emailRequired": "A valid email is required.",
       "nameRequired": "Enter at least a company name or a contact name.",
-      "inviteAlreadyPendingToast": "Customer saved. An invitation for this address is already open — cancel it on the Invitations tab before sending a new one."
+      "inviteAlreadyPendingToast": "Customer saved. An invitation for this address is already open — cancel it on the Invitations tab before sending a new one.",
+      "inviteAlreadyActiveToast": "Customer saved. This address already has portal access, so no invitation was needed.",
+      "inviteUnconfirmedToast": "Customer saved, but the invitation could not be confirmed — the server did not answer. Check the Invitations tab before sending another."
     },
     "passive": {
       "badge": "Passive — admin only",
@@ -5049,7 +5051,7 @@
     },
     "invitePending": {
       "badge": "Invitation pending",
-      "hint": "Invitation sent, not accepted yet. The customer stays passive until they set a password."
+      "hint": "An invitation link for this address is open and has not been accepted. That is not proof the email reached them — check System health if they say it never arrived."
     }
   },
   "clients": {

--- a/frontend/src/pages/admin/CustomerManagementPage.tsx
+++ b/frontend/src/pages/admin/CustomerManagementPage.tsx
@@ -19,7 +19,7 @@ import { Link } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import {
-  UserPlus, UserCog, Trash2, Search, X, AlertTriangle, CheckCircle2, Clock,
+  UserPlus, UserCog, Trash2, Search, X, AlertTriangle, CheckCircle2, Clock, MailCheck,
 } from 'lucide-react';
 import { InlineCustomerCreate } from '../../components/admin/InlineCustomerCreate';
 import { useMutationWithToast } from '../../hooks';
@@ -88,6 +88,18 @@ export const CustomerManagementPage: React.FC = () => {
       || (c.companyName || '').toLowerCase().includes(term)
     );
   }, [customers, debouncedTerm]);
+
+  // #1261 — the "Invite customer" flow is createDirect-then-sendInvite, so a
+  // customer whose second call never landed is left looking identical to one
+  // the admin deliberately created as passive. Both showed only
+  // "Passive — admin only", and there was nothing on this row to tell them
+  // apart. Cross-reference the invitations we already fetch (the endpoint
+  // returns unaccepted, unexpired ones) so an invited customer says so.
+  const pendingInviteByEmail = useMemo(() => {
+    const map = new Map<string, CustomerInvitationSummary>();
+    for (const i of invitations || []) map.set(i.email.trim().toLowerCase(), i);
+    return map;
+  }, [invitations]);
 
   const filteredInvitations = useMemo(() => {
     const list = invitations || [];
@@ -239,11 +251,23 @@ export const CustomerManagementPage: React.FC = () => {
                               status badge sits on its own line so a
                               passive deactivated customer can still
                               show both states clearly. */}
-                          {c.isPassive && (
-                            <span className="inline-flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded bg-neutral-100 dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300">
-                              {t('customers.passive.badge', 'Passive — admin only')}
-                            </span>
-                          )}
+                          {c.isPassive && (() => {
+                            const invite = pendingInviteByEmail.get(c.email.trim().toLowerCase());
+                            return invite ? (
+                              <span
+                                className="inline-flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-300"
+                                title={t('customers.invitePending.hint',
+                                  'Invitation sent, not accepted yet. The customer stays passive until they set a password.') as string}
+                              >
+                                <MailCheck className="w-3 h-3" />
+                                {t('customers.invitePending.badge', 'Invitation pending')}
+                              </span>
+                            ) : (
+                              <span className="inline-flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded bg-neutral-100 dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300">
+                                {t('customers.passive.badge', 'Passive — admin only')}
+                              </span>
+                            );
+                          })()}
                         </div>
                       </td>
                       <td className="px-3 py-3 text-right">

--- a/frontend/src/pages/admin/CustomerManagementPage.tsx
+++ b/frontend/src/pages/admin/CustomerManagementPage.tsx
@@ -256,8 +256,13 @@ export const CustomerManagementPage: React.FC = () => {
                             return invite ? (
                               <span
                                 className="inline-flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-300"
+                                // Deliberately describes the invitation ROW, not a
+                                // delivery. createInvitation inserts the row and then
+                                // queues the email without a transaction, so an open
+                                // invitation does not prove an email_queue row exists,
+                                // let alone that anything was delivered.
                                 title={t('customers.invitePending.hint',
-                                  'Invitation sent, not accepted yet. The customer stays passive until they set a password.') as string}
+                                  'An invitation link for this address is open and has not been accepted. That is not proof the email reached them — check System health if they say it never arrived.') as string}
                               >
                                 <MailCheck className="w-3 h-3" />
                                 {t('customers.invitePending.badge', 'Invitation pending')}

--- a/frontend/src/pages/admin/__tests__/customerInvitationVisibility.test.tsx
+++ b/frontend/src/pages/admin/__tests__/customerInvitationVisibility.test.tsx
@@ -165,9 +165,12 @@ describe('InlineCustomerCreate — what the toast may claim (#1261)', () => {
     expect(message).not.toMatch(/invitation sent/i);
   });
 
-  it('says the customer is PASSIVE when the invitation call failed', async () => {
+  it('says the customer is PASSIVE when the invitation was cleanly rejected', async () => {
+    // A 400 is the shape where "no invitation went out, retry" is true: the
+    // request never got as far as writing anything. Round 2 moved 5xx out of
+    // this branch, because a 500 can leave an invitation row behind.
     createDirect.mockResolvedValue({ id: 6, email: 'new@example.com' });
-    sendInvite.mockRejectedValue({ response: { status: 500 } });
+    sendInvite.mockRejectedValue({ response: { status: 400, data: {} } });
 
     renderWith(<InlineCustomerCreate mode="invite" onCreated={() => {}} onCancel={() => {}} />);
     await fill();
@@ -210,6 +213,57 @@ describe('InlineCustomerCreate — what the toast may claim (#1261)', () => {
     const message = String(toastInfo.mock.calls[0][0]);
     expect(message).toMatch(/already has portal access/i);
     expect(message).not.toMatch(/Invitations tab/i);
+    expect(toastWarn).not.toHaveBeenCalled();
+  });
+
+  it('stays indeterminate on a 5xx — the invitation row may already exist', async () => {
+    // Codex review round 2. createInvitation inserts customer_invitations and
+    // only then queues the email, with no transaction around the pair, so a
+    // 500 out of the queueing step leaves an open invitation behind. Telling
+    // the admin to retry sends them into a 409 that still queues nothing.
+    createDirect.mockResolvedValue({ id: 11, email: 'new@example.com' });
+    sendInvite.mockRejectedValue({ response: { status: 500, data: {} } });
+
+    renderWith(<InlineCustomerCreate mode="invite" onCreated={() => {}} onCancel={() => {}} />);
+    await fill();
+    await userEvent.click(screen.getByRole('button', { name: /Save & send portal invitation/i }));
+
+    await waitFor(() => expect(toastWarn).toHaveBeenCalled());
+    const message = String(toastWarn.mock.calls[0][0]);
+    expect(message).toMatch(/could not be confirmed/i);
+    expect(message).not.toMatch(/PASSIVE/);
+  });
+
+  it('still calls a plain 4xx a clean failure, where retrying is right', async () => {
+    // The one case where "nothing happened, go ahead and retry" is true: the
+    // request was rejected before anything was written.
+    createDirect.mockResolvedValue({ id: 12, email: 'new@example.com' });
+    sendInvite.mockRejectedValue({ response: { status: 403, data: {} } });
+
+    renderWith(<InlineCustomerCreate mode="invite" onCreated={() => {}} onCancel={() => {}} />);
+    await fill();
+    await userEvent.click(screen.getByRole('button', { name: /Save & send portal invitation/i }));
+
+    await waitFor(() => expect(toastWarn).toHaveBeenCalled());
+    expect(String(toastWarn.mock.calls[0][0])).toMatch(/PASSIVE/);
+  });
+
+  it('reads the service-level already-active 409, not just the route-level one', async () => {
+    // Codex review round 2. createInvitation's own recheck throws
+    // ConflictError, which used to serialise as code CONFLICT — indistinguishable
+    // from the pending-invitation conflict, so the admin was told to cancel an
+    // invitation that acceptance had already closed. The service now labels it.
+    createDirect.mockResolvedValue({ id: 13, email: 'new@example.com' });
+    sendInvite.mockRejectedValue({
+      response: { status: 409, data: { code: 'CUSTOMER_ALREADY_ACTIVE', error: 'A customer account with this email already exists' } },
+    });
+
+    renderWith(<InlineCustomerCreate mode="invite" onCreated={() => {}} onCancel={() => {}} />);
+    await fill();
+    await userEvent.click(screen.getByRole('button', { name: /Save & send portal invitation/i }));
+
+    await waitFor(() => expect(toastInfo).toHaveBeenCalled());
+    expect(String(toastInfo.mock.calls[0][0])).toMatch(/already has portal access/i);
     expect(toastWarn).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/pages/admin/__tests__/customerInvitationVisibility.test.tsx
+++ b/frontend/src/pages/admin/__tests__/customerInvitationVisibility.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * "Invite customer" is two calls: createDirect, then sendInvite. When the
+ * second one doesn't land, what's left behind is a passive customer — and the
+ * customers table rendered that identically to one the admin created as
+ * passive on purpose. Both showed "Passive — admin only", so the row could not
+ * answer the only question the admin had: did the invitation go out? (#1261)
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('react-i18next', async () => {
+  const actual = await vi.importActual<typeof import('react-i18next')>('react-i18next');
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (k: string, fb?: unknown) => (typeof fb === 'string' ? fb : k),
+      i18n: { language: 'en' },
+    }),
+  };
+});
+
+vi.mock('react-toastify', () => ({
+  toast: { success: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+import { toast } from 'react-toastify';
+const toastSuccess = toast.success as ReturnType<typeof vi.fn>;
+const toastWarn = toast.warn as ReturnType<typeof vi.fn>;
+
+vi.mock('../../../contexts/PermissionsContext', () => ({
+  usePermissions: () => ({
+    hasPermission: () => true,
+    hasAnyPermission: () => true,
+    hasAllPermissions: () => true,
+    isSuperAdmin: true,
+    isLoading: false,
+  }),
+}));
+
+const list = vi.fn();
+const listInvitations = vi.fn();
+const createDirect = vi.fn();
+const sendInvite = vi.fn();
+vi.mock('../../../services/customerAdmin.service', () => ({
+  customerAdminService: {
+    list: (...a: unknown[]) => list(...a),
+    listInvitations: (...a: unknown[]) => listInvitations(...a),
+    createDirect: (...a: unknown[]) => createDirect(...a),
+    sendInvite: (...a: unknown[]) => sendInvite(...a),
+    deactivate: vi.fn(),
+    cancelInvitation: vi.fn(),
+  },
+}));
+
+vi.mock('../../../services/businessProfile.service', () => ({
+  businessProfileService: { get: vi.fn().mockResolvedValue({ profile: {} }) },
+}));
+
+import { CustomerManagementPage } from '../CustomerManagementPage';
+import { InlineCustomerCreate } from '../../../components/admin/InlineCustomerCreate';
+
+const customer = (id: number, email: string, extra: Record<string, unknown> = {}) => ({
+  id,
+  email,
+  displayName: `Customer ${id}`,
+  firstName: null,
+  lastName: null,
+  salutation: null,
+  companyName: null,
+  isActive: true,
+  isPassive: true,
+  eventCount: 0,
+  lastLogin: null,
+  ...extra,
+});
+
+const invitation = (id: number, email: string) => ({
+  id,
+  email,
+  expiresAt: '2026-12-01T00:00:00.000Z',
+  createdAt: '2026-09-01T00:00:00.000Z',
+  invitedBy: 'admin',
+});
+
+function renderWith(node: React.ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>{node}</MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listInvitations.mockResolvedValue([]);
+  list.mockResolvedValue([]);
+});
+
+describe('CustomerManagementPage — invited vs merely passive (#1261)', () => {
+  it('marks a passive customer who has an open invitation', async () => {
+    list.mockResolvedValue([customer(1, 'invited@example.com')]);
+    listInvitations.mockResolvedValue([invitation(9, 'invited@example.com')]);
+
+    renderWith(<CustomerManagementPage />);
+
+    expect(await screen.findByText('Invitation pending')).toBeTruthy();
+    expect(screen.queryByText('Passive — admin only')).toBeNull();
+  });
+
+  it('leaves a passive customer with no invitation reading as passive', async () => {
+    list.mockResolvedValue([customer(2, 'nobody@example.com')]);
+    listInvitations.mockResolvedValue([]);
+
+    renderWith(<CustomerManagementPage />);
+
+    expect(await screen.findByText('Passive — admin only')).toBeTruthy();
+    expect(screen.queryByText('Invitation pending')).toBeNull();
+  });
+
+  it('matches the invitation regardless of address casing', async () => {
+    // customer_invitations stores the address lowercased; customer_accounts
+    // preserves what the admin typed. A case-sensitive match would show every
+    // mixed-case customer as never invited.
+    list.mockResolvedValue([customer(3, 'Mixed.Case@Example.com')]);
+    listInvitations.mockResolvedValue([invitation(11, 'mixed.case@example.com')]);
+
+    renderWith(<CustomerManagementPage />);
+
+    expect(await screen.findByText('Invitation pending')).toBeTruthy();
+  });
+
+  it('does not mark an active customer, who needs no invitation', async () => {
+    list.mockResolvedValue([customer(4, 'active@example.com', { isPassive: false })]);
+    listInvitations.mockResolvedValue([invitation(12, 'active@example.com')]);
+
+    renderWith(<CustomerManagementPage />);
+
+    await screen.findByText('Customer 4');
+    expect(screen.queryByText('Invitation pending')).toBeNull();
+  });
+});
+
+describe('InlineCustomerCreate — what the toast may claim (#1261)', () => {
+  const fill = async () => {
+    await userEvent.type(screen.getByPlaceholderText('name@example.com'), 'new@example.com');
+    await userEvent.type(screen.getByLabelText(/Company name/i), 'Acme');
+  };
+
+  it('says queued, not sent — this code cannot know it was delivered', async () => {
+    createDirect.mockResolvedValue({ id: 5, email: 'new@example.com' });
+    sendInvite.mockResolvedValue({ id: 1, email: 'new@example.com', expiresAt: 'x' });
+
+    renderWith(<InlineCustomerCreate mode="invite" onCreated={() => {}} onCancel={() => {}} />);
+    await fill();
+    await userEvent.click(screen.getByRole('button', { name: /Save & send portal invitation/i }));
+
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
+    const message = String(toastSuccess.mock.calls[0][0]);
+    expect(message).toMatch(/queued/i);
+    expect(message).not.toMatch(/invitation sent/i);
+  });
+
+  it('says the customer is PASSIVE when the invitation call failed', async () => {
+    createDirect.mockResolvedValue({ id: 6, email: 'new@example.com' });
+    sendInvite.mockRejectedValue({ response: { status: 500 } });
+
+    renderWith(<InlineCustomerCreate mode="invite" onCreated={() => {}} onCancel={() => {}} />);
+    await fill();
+    await userEvent.click(screen.getByRole('button', { name: /Save & send portal invitation/i }));
+
+    await waitFor(() => expect(toastWarn).toHaveBeenCalled());
+    expect(String(toastWarn.mock.calls[0][0])).toMatch(/PASSIVE/);
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
+  it('distinguishes a 409 — the customer IS invited, the re-invite was refused', async () => {
+    createDirect.mockResolvedValue({ id: 7, email: 'new@example.com' });
+    sendInvite.mockRejectedValue({ response: { status: 409 } });
+
+    renderWith(<InlineCustomerCreate mode="invite" onCreated={() => {}} onCancel={() => {}} />);
+    await fill();
+    await userEvent.click(screen.getByRole('button', { name: /Save & send portal invitation/i }));
+
+    await waitFor(() => expect(toastWarn).toHaveBeenCalled());
+    const message = String(toastWarn.mock.calls[0][0]);
+    expect(message).toMatch(/already open/i);
+    expect(message).not.toMatch(/PASSIVE/);
+  });
+});

--- a/frontend/src/pages/admin/__tests__/customerInvitationVisibility.test.tsx
+++ b/frontend/src/pages/admin/__tests__/customerInvitationVisibility.test.tsx
@@ -29,6 +29,7 @@ vi.mock('react-toastify', () => ({
 import { toast } from 'react-toastify';
 const toastSuccess = toast.success as ReturnType<typeof vi.fn>;
 const toastWarn = toast.warn as ReturnType<typeof vi.fn>;
+const toastInfo = toast.info as ReturnType<typeof vi.fn>;
 
 vi.mock('../../../contexts/PermissionsContext', () => ({
   usePermissions: () => ({
@@ -189,5 +190,58 @@ describe('InlineCustomerCreate — what the toast may claim (#1261)', () => {
     const message = String(toastWarn.mock.calls[0][0]);
     expect(message).toMatch(/already open/i);
     expect(message).not.toMatch(/PASSIVE/);
+  });
+
+  it('separates CUSTOMER_ALREADY_ACTIVE from a pending-invitation 409', async () => {
+    // Codex review round 1. Both conflicts are 409. This one means an open
+    // invitation was accepted between createDirect and sendInvite, so there is
+    // no invitation row to cancel — sending the admin to the Invitations tab
+    // points them at something that does not exist.
+    createDirect.mockResolvedValue({ id: 8, email: 'new@example.com' });
+    sendInvite.mockRejectedValue({
+      response: { status: 409, data: { code: 'CUSTOMER_ALREADY_ACTIVE' } },
+    });
+
+    renderWith(<InlineCustomerCreate mode="invite" onCreated={() => {}} onCancel={() => {}} />);
+    await fill();
+    await userEvent.click(screen.getByRole('button', { name: /Save & send portal invitation/i }));
+
+    await waitFor(() => expect(toastInfo).toHaveBeenCalled());
+    const message = String(toastInfo.mock.calls[0][0]);
+    expect(message).toMatch(/already has portal access/i);
+    expect(message).not.toMatch(/Invitations tab/i);
+    expect(toastWarn).not.toHaveBeenCalled();
+  });
+
+  it('stays indeterminate when the server never answered', async () => {
+    // Codex review round 1. A dropped connection or timeout rejects with no
+    // `response`, but the request may have succeeded server-side. Declaring
+    // "no invitation went out" sends the admin into a retry that then 409s.
+    createDirect.mockResolvedValue({ id: 9, email: 'new@example.com' });
+    sendInvite.mockRejectedValue(new Error('Network Error'));
+
+    renderWith(<InlineCustomerCreate mode="invite" onCreated={() => {}} onCancel={() => {}} />);
+    await fill();
+    await userEvent.click(screen.getByRole('button', { name: /Save & send portal invitation/i }));
+
+    await waitFor(() => expect(toastWarn).toHaveBeenCalled());
+    const message = String(toastWarn.mock.calls[0][0]);
+    expect(message).toMatch(/could not be confirmed/i);
+    expect(message).not.toMatch(/PASSIVE/);
+  });
+
+  it('does not claim the invitation email was delivered', async () => {
+    // createInvitation inserts the customer_invitations row and only then
+    // queues the email, without a transaction — so an open invitation is not
+    // evidence that an email_queue row exists, let alone that it was sent.
+    list.mockResolvedValue([customer(10, 'invited@example.com')]);
+    listInvitations.mockResolvedValue([invitation(20, 'invited@example.com')]);
+
+    renderWith(<CustomerManagementPage />);
+
+    const badge = await screen.findByText('Invitation pending');
+    const tooltip = badge.getAttribute('title') || badge.closest('[title]')?.getAttribute('title') || '';
+    expect(tooltip).not.toMatch(/invitation sent/i);
+    expect(tooltip).toMatch(/not proof/i);
   });
 });


### PR DESCRIPTION
Closes #1261.

## What I checked first

The mode wiring is correct. `CustomerManagementPage.tsx:342` passes `mode={createMode}`, and `InlineCustomerCreate.tsx` does call `customerAdminService.sendInvite(customer.id)` in the `invite` branch. So the reported symptom is not the passive path being taken by accident.

What it actually is: nothing downstream distinguishes the three outcomes of a two-call flow.

## Root cause

"Invite customer" is `createDirect` then `sendInvite`, and afterwards these were indistinguishable:

1. **The success toast claimed "portal invitation sent".** `sendInvite` only queues an `email_queue` row (`customerAccountsService.js:174`); whether it was delivered is decided minutes later by the queue processor. That is a claim this code cannot make — and it is the same class as #1262.
2. **A failed `sendInvite` read "Invitation email failed — retry from the customer detail page"**, which sounds like the mail bounced. What actually remains is a PASSIVE customer with no invitation at all.
3. **The customers table rendered a customer whose invitation never went out identically to one the admin created as passive on purpose** — both showed only "Passive — admin only". The row could not answer the only question the admin had.

## Fix

- The toast says **queued**, and says what sends it.
- The failure warning says the customer is **PASSIVE and no invitation went out**, which is the state that needs acting on.
- **A 409 is separated out.** That means an invitation for the address is already open and the RE-invite was refused — the customer *is* invited, so telling them to retry sends them the wrong way. They're pointed at the Invitations tab instead.
- Passive customers with an open invitation show **"Invitation pending"** instead of "Passive — admin only". Matched case-insensitively, because `customer_invitations` lowercases the address (`createInvitation` normalises) while `customer_accounts` keeps what the admin typed — a case-sensitive match would show every mixed-case customer as never invited.

The invitations list was already being fetched for the Invitations tab, and `getPendingInvitations()` already filters to unaccepted + unexpired, so this only cross-references what is on the page. Active customers are left alone: they have portal access, so a stale invitation row for their address says nothing about them.

## Screenshots

Two customers created through the real admin UI: **Sabine Wolf** via "Create passive customer" (deliberately passive), **Jonas Reiter** via "Invite customer" (email typed as `Jonas.Reiter@Example.com` to exercise the casing path).

**Before — the invited customer and the deliberately passive one are identical:**

![before](https://raw.githubusercontent.com/PicPeak/picpeak/screenshots/queue-invite-taps-1261-1263/1261-before-table.png)

**After — the badge distinguishes them, and the toast says queued rather than sent:**

![after](https://raw.githubusercontent.com/PicPeak/picpeak/screenshots/queue-invite-taps-1261-1263/1261-after-toast.png)

## Tests

`frontend/src/pages/admin/__tests__/customerInvitationVisibility.test.tsx` — 7 tests. The 5 that assert the new behaviour all fail against `main`; the 2 negative controls (a passive customer with no invitation stays "Passive", an active customer is never badged) pass on both sides, which is the point of including them.

Full frontend suite green (453 passed).



---

## Review rounds

Three rounds of external review (Codex); converged with no findings on round 3.

**Round 1** — three findings, all valid, all the same shape as the bug itself (claiming more than the code can know):
- The badge tooltip said "Invitation sent". `createInvitation` inserts the `customer_invitations` row and *then* queues the email, with no transaction around the pair, so an open invitation does not prove an `email_queue` row exists — let alone that anything was delivered. The tooltip now describes the invitation link and points at System health.
- A dropped connection or timeout rejects with no `response`, but the request may have succeeded server-side; asserting "no invitation went out" there walks the admin into a retry that then 409s.
- The route's `CUSTOMER_ALREADY_ACTIVE` 409 was conflated with the pending-invitation 409.

**Round 2** — two more:
- A **5xx** is not a clean failure either, for the same non-transactional reason: a 500 out of the queueing step leaves an open invitation behind. 5xx now joins the no-response case as unconfirmed; a plain 4xx keeps the clean-failure message, since that is the one shape where nothing was written.
- `createInvitation` rechecks `customer_accounts` *after* the route's own check and threw a bare `ConflictError` — code `CONFLICT`, indistinguishable from the pending-invitation conflict. An invitation accepted between the two checks therefore landed in the pending branch, telling the admin to cancel an invitation that acceptance had just closed. Both conflicts in the service now carry a code of their own (`backend/src/services/customerAccountsService.js`), so the client reads the code rather than inferring from the status.

**Round 3** — no actionable findings.

One round-1 test changed with the behaviour it pinned: its 500 now asserts the unconfirmed message, and a new 400 case covers the clean failure it used to stand for.

**Verification:** frontend 459 passed, backend customer-account suites 713 passed, typecheck clean.
