### PR TITLE
fix(security): stop a gallery viewer's own image fetches spending the anonymous budget

### DIFF
--- a/backend/__tests__/middleware/galleryImageRateLimitSkip.test.js
+++ b/backend/__tests__/middleware/galleryImageRateLimitSkip.test.js
@@ -1,0 +1,83 @@
+/**
+ * A verified gallery viewer's own image fetches do not spend the anonymous
+ * per-IP budget (#1287).
+ *
+ * Since gallery tokens stopped earning the authenticated skip, a guest on a
+ * 546-photo grid ran out of the default 300 requests per 15 minutes
+ * mid-scroll; the rest of the tiles came back 429 and rendered blank, and the
+ * next refresh found the photo list limited too. Reproduced in iOS Safari
+ * against a seeded gallery: loading in bursts, then nothing, no error
+ * anywhere. The image routes are exempt for a token that verifies and names
+ * the gallery in the path; everything else stays on the budget.
+ */
+const jwt = require('jsonwebtoken');
+
+process.env.JWT_SECRET = 'gallery-image-skip-secret';
+
+jest.mock('../../src/database/db', () => ({ db: jest.fn(), withRetry: (fn) => fn() }));
+jest.mock('../../src/utils/logger', () => ({ error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() }));
+
+const { isOwnGalleryImageRequest, shouldSkipRateLimit } = require('../../src/services/rateLimitService');
+
+const iat = Math.floor(Date.now() / 1000) - 10;
+const galleryToken = (eventSlug) => jwt.sign({ type: 'gallery', eventId: 1, eventSlug, iat }, process.env.JWT_SECRET, { issuer: 'picpeak-auth' });
+const adminToken = () => jwt.sign({ type: 'admin', id: 1, iat }, process.env.JWT_SECRET, { issuer: 'picpeak-auth' });
+const req = (path, token, method = 'GET') => ({
+  path, method, cookies: {}, headers: token ? { authorization: `Bearer ${token}` } : {},
+});
+const config = { enabled: true, skipAuthenticated: true, publicEndpointsOnly: false };
+
+describe('a gallery viewer fetching its own images', () => {
+  it.each(['thumbnail', 'preview', 'hero', 'photo'])('skips the budget on /%s', (route) => {
+    const r = req(`/api/gallery/wedding-2026/${route}/42`, galleryToken('wedding-2026'));
+    expect(isOwnGalleryImageRequest(r)).toBe(true);
+    expect(shouldSkipRateLimit(r, config)).toBe(true);
+  });
+
+  it('also reads the per-slug gallery cookie, as the browser sends it', () => {
+    const r = { path: '/api/gallery/wedding-2026/thumbnail/42', method: 'GET', headers: {},
+      cookies: { 'gallery_token_wedding-2026': galleryToken('wedding-2026') } };
+    expect(isOwnGalleryImageRequest(r)).toBe(true);
+  });
+});
+
+describe('everything else stays on the budget', () => {
+  it('the photo list, downloads and feedback', () => {
+    const token = galleryToken('wedding-2026');
+    for (const path of ['/api/gallery/wedding-2026/photos', '/api/gallery/wedding-2026/download/42',
+      '/api/gallery/wedding-2026/download-all', '/api/gallery/wedding-2026/info', '/api/gallery/wedding-2026/feedback/42']) {
+      expect(isOwnGalleryImageRequest(req(path, token))).toBe(false);
+      expect(shouldSkipRateLimit(req(path, token), config)).toBe(false);
+    }
+  });
+
+  it('a token minted for a different gallery', () => {
+    const r = req('/api/gallery/wedding-2026/thumbnail/42', galleryToken('other-gallery'));
+    expect(isOwnGalleryImageRequest(r)).toBe(false);
+    expect(shouldSkipRateLimit(r, config)).toBe(false);
+  });
+
+  it('no token, a garbage token, a token under another secret, a token without a slug', () => {
+    const path = '/api/gallery/wedding-2026/thumbnail/42';
+    const foreign = jwt.sign({ type: 'gallery', eventSlug: 'wedding-2026', iat }, 'someone-elses-secret');
+    const slugless = jwt.sign({ type: 'gallery', eventId: 1, iat }, process.env.JWT_SECRET);
+    for (const token of [undefined, 'not-a-jwt', foreign, slugless]) {
+      expect(isOwnGalleryImageRequest(req(path, token))).toBe(false);
+    }
+  });
+
+  it('a non-GET on an image path', () => {
+    expect(isOwnGalleryImageRequest(req('/api/gallery/wedding-2026/photo/42', galleryToken('wedding-2026'), 'DELETE'))).toBe(false);
+  });
+
+  it('an admin token still skips everywhere, and is not what this checks', () => {
+    const r = req('/api/gallery/wedding-2026/thumbnail/42', adminToken());
+    expect(isOwnGalleryImageRequest(r)).toBe(false);
+    expect(shouldSkipRateLimit(r, config)).toBe(true);
+  });
+
+  it('the operator switch skip_authenticated=false counts guests too', () => {
+    const r = req('/api/gallery/wedding-2026/thumbnail/42', galleryToken('wedding-2026'));
+    expect(shouldSkipRateLimit(r, { ...config, skipAuthenticated: false })).toBe(false);
+  });
+});

--- a/backend/src/services/rateLimitService.js
+++ b/backend/src/services/rateLimitService.js
@@ -118,6 +118,8 @@ function isAuthenticated(req) {
     // Only an admin session earns the skip. A gallery token is minted for
     // free on password-less galleries and slideshow links, so treating it as
     // "authenticated" handed anyone an unlimited budget on every /api route.
+    // The one thing a gallery token does buy is its own gallery's images —
+    // see isOwnGalleryImageRequest below.
     if (decoded.type !== 'admin') {
       return false;
     }
@@ -125,6 +127,46 @@ function isAuthenticated(req) {
     req.tokenPayload = decoded;
     
     return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+// The routes a gallery viewer fetches once per tile: thumbnail, preview,
+// hero, photo. Downloads, the photo list, feedback and everything else stay
+// on the budget.
+const GALLERY_IMAGE_RE = /^\/api\/gallery\/([^/]+)\/(thumbnail|preview|hero|photo)\/[^/]+$/i;
+
+/**
+ * A verified gallery viewer fetching that gallery's own images (#1287).
+ *
+ * Since gallery tokens stopped earning the authenticated skip, every guest
+ * has been spending the anonymous per-IP budget — 300 requests per 15
+ * minutes by default — on the gallery's thumbnails. A 546-photo grid runs
+ * out of budget mid-scroll: the remaining tiles come back 429, which the
+ * frontend rendered as blank tiles with no error, and the next refresh
+ * finds the photo list rate-limited too. A per-IP limit that one legitimate
+ * viewer exhausts on one gallery protects nothing.
+ *
+ * So a token that verifies AND names the gallery in the path is exempt on
+ * the image routes only. The token proves the viewer passed whatever gate
+ * the gallery has (the gate itself is still limited), the slug check stops a
+ * token for one gallery buying images from another, and GET-only keeps every
+ * write on the budget. The bandwidth these routes cost was never something a
+ * 300-request budget bounded — a viewer can refetch a cached thumbnail 300
+ * times too — so nothing is given up here that the budget actually held.
+ */
+function isOwnGalleryImageRequest(req) {
+  if (req.method && req.method !== 'GET') return false;
+  const match = (req.path || '').match(GALLERY_IMAGE_RE);
+  if (!match) return false;
+  const slug = match[1];
+  try {
+    const token = getGalleryTokenFromRequest(req, slug);
+    if (!token) return false;
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    return Boolean(decoded) && typeof decoded === 'object'
+      && decoded.type === 'gallery' && decoded.eventSlug === slug;
   } catch (error) {
     return false;
   }
@@ -145,8 +187,10 @@ function shouldSkipRateLimit(req, config) {
     return false;
   }
 
-  // Check if we should skip authenticated requests
-  if (config.skipAuthenticated && isAuthenticated(req)) {
+  // Check if we should skip authenticated requests. A gallery viewer's own
+  // image fetches ride on the same switch: an operator who turns the skip
+  // off gets every request counted, guests included.
+  if (config.skipAuthenticated && (isAuthenticated(req) || isOwnGalleryImageRequest(req))) {
     return true;
   }
 
@@ -292,5 +336,6 @@ module.exports = {
   createRateLimiter,
   createAuthRateLimiter,
   isAuthenticated,
+  isOwnGalleryImageRequest,
   shouldSkipRateLimit
 };


### PR DESCRIPTION
## What this changes

A gallery token that verifies and names the gallery in the path is exempt from the general rate limiter on the image routes: `thumbnail`, `preview`, `hero`, `photo`, GET only. The photo list, downloads, feedback and every write stay on the budget. A token for gallery A buys nothing on gallery B, and the exemption rides on `rate_limit_skip_authenticated`: an operator who turns the skip off counts guests too.

## Why

The general per-IP limiter had been inert since it was written, until `b0f33c17` registered it ahead of the routers on 1 September, with a budget of 100, raised to 300 by `19e125d8`. On 3 September `839bf4e4` stopped gallery tokens from earning the "authenticated" skip. Since that version every guest has been paying for the gallery's thumbnails out of 300 requests per 15 minutes per IP. A 546-photo grid runs out mid-scroll: the remaining tiles come back 429, the frontend turned those into blank tiles with no error and no retry, and the next refresh hits the same limit with the photo list.

Reproduced in iOS Safari in the Xcode simulator against a seeded 546-photo Grid gallery: loading in bursts, then nothing, no console output, no recovery, and 141 `Rate limit exceeded` lines in the backend log. That is the shape of the report in issue 1287, whose plateaus were 125, 235, 300 and 308 tiles; one of them is the budget itself.

## What 839bf4e4 wanted stays

The concern there was a freely minted token as an unlimited budget on **every** `/api` route. That stays closed. What this hands back is the bandwidth of routes a 300-request budget never bounded anyway: a viewer can refetch a cached thumbnail 300 times too. The gate itself (`verify`) stays limited, and a password-less gallery is public anyway.

## Tests

`galleryImageRateLimitSkip.test.js`, nine cases: the four image routes are skipped with a Bearer token and with the per-slug cookie; the photo list, downloads, info and feedback are not; a foreign slug, no token, a garbage token, a foreign secret, a token without a slug and a non-GET are not; an admin token behaves as before; `skip_authenticated=false` counts everything. `securityHardeningBatch2`, `apiRateLimitGate` and `authRateLimitGate` unchanged and green. Codex review: no findings.

## On the issue

After the measurement this is the most likely mechanism behind issue 1287, but confirmation from the reporter's install is still pending (`grep -c "Rate limit exceeded"` in the backend log). The issue stays open until it arrives. No closing keyword, on purpose.
