### PR TITLE
fix(usage): stop WebKit collapsing the consent dialog to its header and footer

### DIFF
--- a/frontend/src/features/settings/__tests__/ProductUsageTab.test.tsx
+++ b/frontend/src/features/settings/__tests__/ProductUsageTab.test.tsx
@@ -305,6 +305,23 @@ it('returns focus to the control that opened the consent dialog', async () => {
   );
 });
 
+// WebKit sizing (Safari, desktop and iOS). The consent dialog is a native
+// <dialog> laid out as a flex column with only a max-height, so its height is
+// indefinite. `flex-1` is `flex: 1 1 0%`, and WebKit resolves that 0% basis
+// against the indefinite height as zero — the disclosure's hypothetical size
+// becomes zero and the dialog shrinks to header plus footer, leaving the
+// text in a 32px strip. Chromium treats the same basis as `content`. Measured
+// in iOS Safari: 302px dialog / 32px region before, 641px / 371px after. An
+// `auto` basis with min-height 0 sizes from content and then shrinks to fit.
+// The div-based modals elsewhere are unaffected; only <dialog> collapses.
+it('sizes the consent disclosure from its content, so WebKit does not collapse the dialog', async () => {
+  mount();
+  fireEvent.click(await screen.findByText('productUsage.review'));
+  const region = await screen.findByRole('group', { name: 'productUsage.consentTitle' });
+  expect(region.className.split(' ')).toEqual(expect.arrayContaining(['flex-auto', 'min-h-0', 'overflow-y-auto']));
+  expect(region.className.split(' ')).not.toContain('flex-1');
+});
+
 // A security property, not a nicety: the consent dialog is where an operator
 // decides whether to open a connection at all, so it has to say which way that
 // connection runs. UsageService makes exactly two outbound POSTs and reads

--- a/frontend/src/features/settings/tabs/ProductUsageTab.tsx
+++ b/frontend/src/features/settings/tabs/ProductUsageTab.tsx
@@ -124,7 +124,7 @@ function ConsentDialog({
         tabIndex={0}
         role="group"
         aria-label={t('productUsage.consentTitle') as string}
-        className="flex-1 overflow-y-auto border-y border-neutral-200 dark:border-neutral-700 px-6 py-4 space-y-4 focus:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-primary-400"
+        className="min-h-0 flex-auto overflow-y-auto border-y border-neutral-200 dark:border-neutral-700 px-6 py-4 space-y-4 focus:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-primary-400"
       >
         {DISCLOSURE.map(({ key, heading, Icon }) => (
           <section key={key}>


### PR DESCRIPTION
## What this changes

In Safari the product-usage consent dialog opened as a 302 px box on a 714 px viewport, with the whole disclosure squeezed into a 32 px strip between header and footer. Chromium showed the same dialog at 85 % of the viewport with a 535 px scrolling region.

The dialog is a native `<dialog>` laid out as a flex column with only a `max-height`, so its own height is indefinite, and the disclosure region used `flex-1`, which is `flex: 1 1 0%`. WebKit resolves that 0 % basis against the indefinite container height as zero: the region's hypothetical size is zero, the dialog sizes to header plus footer, and the max-height never comes into play. Chromium treats the same basis as `content`.

Fix: `min-h-0 flex-auto` on the region, an `auto` basis with min-height 0. It sizes from its content and then shrinks to the max-height. Measured in iOS Safari (Xcode simulator, iPhone 17 Pro, iOS 26.4): dialog 641 px, scrolling region 371 px, footer on screen, matching Chromium.

## Scope

Only the `<dialog>` is affected. Seven other modals use the same `flex-1 overflow-y-auto` pattern inside a `max-h` flex column as plain divs; a synthetic page with all four combinations, measured in the same WebKit, collapses only the `<dialog>` + `flex-1` variant (box 104 px, region 0 px), while the div variants and the `flex-auto` dialog size correctly (641 px / 537 px). So those modals stay as they are.

Desktop Safari could not be driven here (WebDriver needs "Allow remote automation", which is off on this machine); the simulator is the same WebKit, and the collapse reproduced there identically to the report.

## Tests

- `ProductUsageTab.test.tsx`: a pin that the disclosure region carries `flex-auto` and `min-h-0` and not `flex-1`, with the reasoning next to it, since jsdom cannot see the layout. 23/23 green.
- `tsc -b` clean, ESLint clean. Codex review: no findings.

## Screenshots

iOS Safari, before and after:

![Before: disclosure collapsed to one heading line](https://raw.githubusercontent.com/PicPeak/picpeak/screenshots/consent-dialog-webkit/consent-dialog-safari-before.png)

![After: dialog at 85 % of the viewport with a scrolling disclosure](https://raw.githubusercontent.com/PicPeak/picpeak/screenshots/consent-dialog-webkit/consent-dialog-safari-after.png)
