### PR TITLE
docs(security): correct the rate limiter defaults and how they are set

### DIFF
--- a/backend/docs/SECURITY_LOGGING.md
+++ b/backend/docs/SECURITY_LOGGING.md
@@ -87,16 +87,18 @@ When rate limits are exceeded, the following is logged:
 
 ## Configuration Settings
 
-All rate limiting settings are configurable via the admin panel:
+The general limiter reads these keys from `app_settings` (cached for 60 seconds). There is no admin screen for them yet; they are set through `PUT /api/admin/settings/security/rate-limit` (all six fields required) or directly in the table, JSON-encoded. The defaults below are what applies when a key has no row — a fresh install has none.
 
 | Setting | Default | Range | Description |
 |---------|---------|-------|-------------|
 | rate_limit_enabled | true | - | Enable/disable rate limiting |
 | rate_limit_window_minutes | 15 | 1-60 | Time window for rate limit |
-| rate_limit_max_requests | 1000 | 10-10000 | Max requests for general endpoints |
-| rate_limit_auth_max_requests | 5 | 1-100 | Max requests for auth endpoints |
-| rate_limit_skip_authenticated | true | - | Skip rate limit for authenticated requests |
-| rate_limit_public_endpoints_only | false | - | Only rate limit public endpoints |
+| rate_limit_max_requests | 300 | 10-10000 | Per-IP budget for `/api/` requests that are not exempt |
+| rate_limit_auth_max_requests | 5 | 1-100 | Per-IP budget of *failed* admin-login / gallery-verify attempts (own bucket) |
+| rate_limit_skip_authenticated | true | - | Admin sessions are exempt; since v3.127.0-beta.0 a verified gallery viewer's image requests (thumbnail, preview, hero, photo) are exempt too |
+| rate_limit_public_endpoints_only | false | - | Only rate limit `/api/public/*` and `/api/gallery/*` |
+
+The limiter keys on the client IP as Express reports it, so behind a proxy `TRUST_PROXY` has to cover that proxy or every visitor shares one budget. Several people behind one NAT (an office, a household, carrier NAT) share a budget by design; before v3.127.0-beta.0 a large gallery could exhaust it for a single viewer, which surfaced as blank tiles with no error (issue 1287).
 
 ## Database Tables
 

--- a/backend/docs/SECURITY_LOGGING.md
+++ b/backend/docs/SECURITY_LOGGING.md
@@ -87,7 +87,7 @@ When rate limits are exceeded, the following is logged:
 
 ## Configuration Settings
 
-The general limiter reads these keys from `app_settings` (cached for 60 seconds). There is no admin screen for them yet; they are set through `PUT /api/admin/settings/security/rate-limit` (all six fields required) or directly in the table, JSON-encoded. The defaults below are what applies when a key has no row — a fresh install has none.
+The general limiter reads these keys from `app_settings` (cached for 60 seconds). There is no admin screen for them yet; they are set through `PUT /api/admin/settings/security/rate-limit` (all six fields required) or directly in the table, JSON-encoded. The defaults below are what applies when a key has no row — a fresh install has none. Note that the route only updates rows that already exist: on a fresh install it answers 200 without writing anything, so insert the six rows directly first.
 
 | Setting | Default | Range | Description |
 |---------|---------|-------|-------------|


### PR DESCRIPTION
## What this changes

`backend/docs/SECURITY_LOGGING.md` stated that `rate_limit_max_requests` defaults to 1000 and that the rate-limit settings are "configurable via the admin panel". Neither is true today:

- the code fallback when no `app_settings` row exists is **300** (`19e125d8`), and a fresh install has no row;
- there is **no admin screen** for these settings — `PUT /api/admin/settings/security/rate-limit` exists in `adminSettings.js`, but nothing in the frontend calls it.

The reporter of issue 1287 ran on the 300 default with no way to see it, and the doc would have sent anyone reading it to a panel that does not exist.

The table now carries the real defaults, what the auth budget counts (failed attempts, own bucket), the exemptions including the gallery-image one shipped in `v3.127.0-beta.0` (#1324), how the values are actually set, and the `TRUST_PROXY` / shared-NAT caveats. The user-facing counterpart is a docs-site PR in PicPeak/docs; the missing UI is filed as its own issue.

Doc-only; no code changes.
