### PR TITLE
fix(events): drop non-canonical keys from the event update before any check runs

### DIFF
--- a/backend/__tests__/routes/authzPermissionGaps.test.js
+++ b/backend/__tests__/routes/authzPermissionGaps.test.js
@@ -137,11 +137,17 @@ describe('authorization / ownership gaps', () => {
         // Case-variant keys — SQLite matches columns case-insensitively.
         Password_Hash: 'case-hijack-hash',
         Created_By: 88888,
+        // A case variant of an ORDINARY column must not reach the UPDATE
+        // either: field-level guards in the handler key on the exact name,
+        // and on SQLite the variant would still land on the real column.
+        Event_Name: 'case-variant-name',
+        Welcome_Message: 'case-variant-welcome',
       });
       expect(res.status).toBe(200);
 
       const row = await db('events').where({ id: eventId }).first();
-      expect(row.event_name).toBe('After');        // legit field applied
+      expect(row.event_name).toBe('After');        // legit field applied; Event_Name variant dropped
+      expect(row.welcome_message).toBeFalsy();      // case variant of an ordinary column dropped
       expect(row.created_by).toBe(superId);         // ownership untouched (+ case-variant)
       expect(row.slug).toBe('authz-mass-assign');   // routing identity untouched
       expect(row.share_token).toBe(seedShareToken); // secret untouched

--- a/backend/src/routes/adminEvents/crud.js
+++ b/backend/src/routes/adminEvents/crud.js
@@ -1729,10 +1729,18 @@ module.exports = (router) => {
         // Legacy mirrors — rejected explicitly below in favour of customer_*.
         'host_name', 'host_email',
       ];
-      // Case-insensitive match: SQLite treats quoted identifiers
-      // case-insensitively, so a `{ "Password_Hash": ... }` key would
-      // otherwise survive a case-sensitive delete and still hit the real
-      // column (codex review).
+      // Only canonical keys reach the UPDATE. SQLite resolves quoted
+      // identifiers case-insensitively, so `{ "Event_Name": ... }` lands on
+      // event_name there while every check in this handler — validators,
+      // the permission guards on individual fields, the deny-set below — is
+      // keyed on the exact lowercase name. Every events column and every
+      // input-only key this handler accepts is lowercase snake_case, so a key
+      // with any uppercase in it is not something a legitimate client sends;
+      // it is dropped before anything looks at it. The deny-set keeps its own
+      // case-folding as belt and braces (GHSA-3rqx).
+      for (const key of Object.keys(updates)) {
+        if (key !== key.toLowerCase()) delete updates[key];
+      }
       const denied = new Set(IMMUTABLE_EVENT_COLUMNS.map((c) => c.toLowerCase()));
       for (const key of Object.keys(updates)) {
         if (denied.has(key.toLowerCase())) delete updates[key];


### PR DESCRIPTION
`PUT /admin/events/:id` spreads the request body into the events UPDATE. SQLite resolves quoted identifiers case-insensitively, so `{ "Event_Name": "x" }` writes `event_name` there — while every check in the handler keys on the exact lowercase name: the express-validator rules, the field-level permission guards, and the deny-set from GHSA-3rqx. The deny-set already case-folds for its own columns; every other column was reachable through a spelling variant on SQLite. Postgres quotes identifiers case-sensitively, so the same body produced a 500 there rather than a write.

## Fix

One loop before anything inspects the body: a key with any uppercase in it is dropped. Every events column and every input-only key the handler accepts (`password`, `client_password`, `customer_account_ids`, `regenerate_client_token`) is lowercase snake_case, so no legitimate client is affected. The deny-set keeps its own case-folding as belt and braces.

## Test

`authzPermissionGaps.test.js` (mass-assignment case) now also sends `Event_Name` and `Welcome_Message` variants and asserts neither lands. Verified the assertion fails without the fix (`Expected: "After", Received: "case-variant-name"`).

## Why now

Surfaced by the external review of PR 1345, where a `photos.upload` guard on `external_watch` could be walked around with `External_Watch`. That PR carries a targeted two-key version of this check; this is the general one and is independent of it.

Pushed with `PUSH_SKIP_E2E=1` (the pre-push E2E hook collides with the local rig).
