### PR TITLE
docs: refresh repository support and community links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,17 +24,20 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Environment (please complete the following information):**
- - OS: [e.g. Ubuntu 22.04]
- - Browser: [e.g. Chrome 120, Safari 17]
- - PicPeak Version: [e.g. 1.0.22]
- - Deployment Method: [e.g. Docker Compose, Manual]
- - Database: [e.g. PostgreSQL 15, SQLite]
+ - OS and version:
+ - Browser and version:
+ - PicPeak version and Docker image tag (if applicable):
+ - Deployment method: [Docker Compose, all-in-one container, manual]
+ - Database and version: [PostgreSQL, SQLite]
 
 **Logs**
 Please include relevant logs:
 ```
-# Backend logs
-docker-compose logs backend | tail -50
+# Backend logs (Docker Compose)
+docker compose logs --tail=50 backend
+
+# Or all-in-one container logs (replace picpeak if your container has another name)
+docker logs --tail=50 picpeak
 
 # Frontend console errors
 [paste any browser console errors]

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: 📚 Documentation
-    url: https://github.com/PicPeak/picpeak/blob/main/DEPLOYMENT.md
-    about: Please read the documentation before opening an issue
+    url: https://docs.picpeak.app
+    about: Installation, configuration and feature guides
   - name: 💬 Discussions
     url: https://github.com/PicPeak/picpeak/discussions
     about: Ask questions and discuss with the community

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -9,12 +9,15 @@ assignees: ''
 
 **What documentation needs improvement?**
 Please specify which document or section needs attention:
+- [ ] Documentation website (https://docs.picpeak.app)
 - [ ] README.md
 - [ ] DEPLOYMENT.md
 - [ ] CONTRIBUTING.md
 - [ ] API Documentation
 - [ ] Code Comments
 - [ ] Other: ___________
+
+Link to the affected page or file:
 
 **Describe the issue**
 What's wrong or missing in the documentation?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Unsure where to begin? You can start by looking through these issues:
 
 ### Prerequisites
 
-- Node.js 18+
+- Node.js 22.12.0 or later (matches `backend/package.json`)
 - Docker & Docker Compose
 - Git
 
@@ -196,6 +196,6 @@ See [RELEASING.md](RELEASING.md) for the full operational doc (promotion criteri
 
 - Create an [issue](https://github.com/PicPeak/picpeak/issues) for bugs or features
 - Join [discussions](https://github.com/PicPeak/picpeak/discussions) for questions
-- Security issues: Open a [security issue](https://github.com/PicPeak/picpeak/issues/new?labels=security) on GitHub
+- Security vulnerabilities: Follow the [security policy](SECURITY.md) and use [private vulnerability reporting](https://github.com/PicPeak/picpeak/security/advisories/new)
 
 Thank you for contributing! 🎉

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Full documentation lives at **[docs.picpeak.app](https://docs.picpeak.app)** —
 | 🧾 CRM & Accounting | [docs.picpeak.app/features/crm](https://docs.picpeak.app/features/crm) · [disclaimers](https://docs.picpeak.app/features/crm/disclaimers) |
 | 🗺️ Roadmap | [GitHub Issues](https://github.com/PicPeak/picpeak/issues) |
 
-**Project meta:** [Contributing](CONTRIBUTING.md) · [License](LICENSE) · [Security](SECURITY.md) · [Code of Conduct](CODE_OF_CONDUCT.md)
+**Project meta:** [Support](SUPPORT.md) · [Contributing](CONTRIBUTING.md) · [License](LICENSE) · [Security](SECURITY.md) · [Code of Conduct](CODE_OF_CONDUCT.md)
 
 ## 📊 Comparison with Alternatives
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,33 @@
+# Getting help with PicPeak
+
+## Documentation
+
+Start with [docs.picpeak.app](https://docs.picpeak.app) for installation,
+configuration, gallery features and administration guides.
+
+- [Getting started](https://docs.picpeak.app/getting-started)
+- [Deployment](https://docs.picpeak.app/deployment)
+- [Admin settings](https://docs.picpeak.app/guides/admin-settings)
+- [Release channels](https://docs.picpeak.app/deployment/release-channels)
+
+## Questions and troubleshooting
+
+Use [GitHub Discussions](https://github.com/PicPeak/picpeak/discussions) for
+setup questions, troubleshooting and advice from the community. Include your
+PicPeak version, deployment method and what you have already tried.
+
+## Bugs and feature requests
+
+Search [existing issues](https://github.com/PicPeak/picpeak/issues) first, then
+[choose an issue template](https://github.com/PicPeak/picpeak/issues/new/choose)
+to report a bug, suggest a feature or identify a documentation problem.
+
+For bugs, include the exact version, reproduction steps and relevant logs.
+See [Contributing](CONTRIBUTING.md) for development and pull request guidance.
+
+## Security vulnerabilities
+
+Follow the [security policy](SECURITY.md) and use
+[private vulnerability reporting](https://github.com/PicPeak/picpeak/security/advisories/new)
+or email **info@picpeak.app**. Do not report vulnerabilities in public issues
+or discussions.


### PR DESCRIPTION
The repository's issue chooser points at the old deployment document, its bug template omits all-in-one installations, and its contributor guide lists an unsupported Node.js minimum. Visitors also lack a dedicated support entry point.

This updates the documentation links and bug-report prompts, adds `SUPPORT.md` linked from the README, and aligns the contributor prerequisite with the backend's Node.js 22.12.0 minimum. The contributor guide's public security-issue link now follows the existing private-reporting policy.

Validation:

- Parsed the issue chooser and all five issue-template front matters; every referenced label exists in the repository.
- Verified the documented Node.js minimum against `backend/package.json`.
- Checked seven website/documentation/discussion URLs: all return HTTP 200.
- `git diff --check` passes. Application tests are not applicable to these documentation and template changes.
