### PR TITLE
fix: complete graceful shutdown and revoke tokens without expiry

### DIFF
--- a/backend/__tests__/integration/tokenRevocationExpiry.test.js
+++ b/backend/__tests__/integration/tokenRevocationExpiry.test.js
@@ -1,0 +1,96 @@
+const knex = require('knex');
+const jwt = require('jsonwebtoken');
+const { randomUUID } = require('crypto');
+const migration = require('../../migrations/core/211_revocations_without_expiry');
+
+for (const client of ['sqlite3', 'pg']) {
+  const enabled = client !== 'pg' || process.env.PICPEAK_PG_TEST_URL;
+  (enabled ? describe : describe.skip)(`token revocation expiry (${client})`, () => {
+    let db, owner, schema, revocation;
+    const sign = claims => jwt.sign({ id: 1, type: 'admin', jti: randomUUID(), ...claims }, process.env.JWT_SECRET);
+
+    beforeAll(async () => {
+      if (client === 'pg') {
+        schema = `revocation_${randomUUID().replace(/-/g, '')}`;
+        owner = knex({ client, connection: process.env.PICPEAK_PG_TEST_URL });
+        await owner.schema.createSchema(schema);
+        db = knex({ client, connection: process.env.PICPEAK_PG_TEST_URL, searchPath: [schema] });
+      } else {
+        db = knex({ client, connection: { filename: ':memory:' }, useNullAsDefault: true });
+      }
+      // Exercise the upgrade from the real legacy NOT NULL schema as well as
+      // repeated migration runs, without sharing another test's database.
+      await require('../../migrations/legacy/017_add_token_revocation_tables').up(db);
+      await db('revoked_tokens').insert({ token_id: 'existing', expires_at: '2099-01-01T00:00:00.000Z' });
+      await migration.up(db);
+      await migration.up(db);
+      jest.resetModules();
+      jest.doMock('../../src/database/db', () => ({ db }));
+      revocation = require('../../src/utils/tokenRevocation');
+    });
+
+    afterAll(async () => {
+      await db?.destroy();
+      if (owner) { await owner.schema.dropSchema(schema, true); await owner.destroy(); }
+      jest.dontMock('../../src/database/db');
+    });
+
+    it('preserves existing revocations and their unique key during upgrade', async () => {
+      expect(await db('revoked_tokens').where({ token_id: 'existing' }).first()).toBeTruthy();
+      await expect(db('revoked_tokens').insert({ token_id: 'existing', expires_at: null })).rejects.toThrow();
+    });
+
+    it.each([true, false])('permanently revokes a token without exp (jti: %s)', async withJti => {
+      const token = sign(withJti ? {} : { jti: undefined });
+      const payload = jwt.verify(token, process.env.JWT_SECRET);
+      expect(await revocation.isTokenRevoked(payload)).toBe(false);
+      expect(await revocation.revokeToken(token, 'logout')).toBe(true);
+      expect(await revocation.revokeToken(token, 'logout')).toBe(true);
+      await revocation.cleanupExpiredRevocations();
+      expect(await revocation.isTokenRevoked(payload)).toBe(true);
+      const rows = await db('revoked_tokens').where({ token_id: revocation.buildTokenId(payload) });
+      expect(rows).toHaveLength(1);
+      expect(rows[0].expires_at).toBeNull();
+    });
+
+    it('cleans up expired revocations and retains future ones', async () => {
+      const expired = sign({ exp: Math.floor(Date.now() / 1000) - 60 });
+      const future = sign({ exp: Math.floor(Date.now() / 1000) + 3600 });
+      expect(await revocation.revokeToken(expired, 'logout')).toBe(true);
+      expect(await revocation.revokeToken(future, 'logout')).toBe(true);
+      await revocation.cleanupExpiredRevocations();
+      expect(await revocation.isTokenRevoked(jwt.decode(expired))).toBe(false);
+      expect(await revocation.isTokenRevoked(jwt.decode(future))).toBe(true);
+    });
+
+    it.each([true, false])('upgrades an expiring entry with the same key permanently (jti: %s)', async withJti => {
+      const claims = { id: 99, iat: Math.floor(Date.now() / 1000), jti: withJti ? randomUUID() : undefined };
+      const expiring = sign({ ...claims, exp: claims.iat - 60 });
+      const permanent = sign(claims);
+      expect(await revocation.revokeToken(expiring, 'logout')).toBe(true);
+      expect(await revocation.revokeToken(permanent, 'logout')).toBe(true);
+      expect(await revocation.revokeToken(expiring, 'logout')).toBe(true);
+      await revocation.cleanupExpiredRevocations();
+      expect(await revocation.isTokenRevoked(jwt.decode(permanent))).toBe(true);
+    });
+
+    it('retains a signed token whose numeric expiry cannot fit a database timestamp', async () => {
+      const token = sign({ exp: 1e100 });
+      expect(await revocation.revokeToken(token, 'logout')).toBe(true);
+      await revocation.cleanupExpiredRevocations();
+      expect(await revocation.isTokenRevoked(jwt.decode(token))).toBe(true);
+    });
+
+    it('refuses a rollback that would remove permanent revocations', async () => {
+      await expect(migration.down(db)).rejects.toThrow('permanent token revocations');
+      expect((await db('revoked_tokens').columnInfo('expires_at')).nullable).toBe(true);
+      // A rollback with only expiring records remains supported and reversible.
+      await db('revoked_tokens').whereNull('expires_at').delete();
+      await migration.down(db);
+      await migration.down(db);
+      expect((await db('revoked_tokens').columnInfo('expires_at')).nullable).toBe(false);
+      await migration.up(db);
+      expect(await db('revoked_tokens').where({ token_id: 'existing' }).first()).toBeTruthy();
+    });
+  });
+}

--- a/backend/__tests__/routes/logoutRevocation.test.js
+++ b/backend/__tests__/routes/logoutRevocation.test.js
@@ -1,0 +1,75 @@
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+const { randomUUID } = require('crypto');
+const { bootCrmDb, seedMinimal, assignAdminRole, buildRouteApp } = require('../integration/helpers/crmDb');
+
+let db, cleanup, adminId, customerId, eventId, apps, revocation;
+const slug = 'logout-revocation';
+const cases = [
+  ['auth', '/logout', 'admin', 'admin_token'],
+  ['auth', '/gallery/logout', 'gallery', `gallery_token_${slug}`],
+  ['customerAuth', '/logout', 'customer', 'customer_token'],
+  ['adminAuth', '/logout', 'admin', 'admin_token'],
+];
+const sign = type => jwt.sign({
+  type, ...(type === 'admin' ? { id: adminId } : type === 'customer' ? { customerId } : { eventId, eventSlug: slug }),
+  jti: randomUUID(),
+}, process.env.JWT_SECRET, { issuer: 'picpeak-auth' });
+
+beforeAll(async () => {
+  ({ db, cleanup } = await bootCrmDb());
+  ({ adminId, customerId } = await seedMinimal(db));
+  await assignAdminRole(db, adminId);
+  const event = await require('../../src/services/eventCreationService').createEvent({
+    event_type: 'wedding', event_name: 'Logout revocation', event_date: '2026-10-01',
+    slug, password: 'Logout-Strong-Password-924!', expiration_days: 30,
+    customer_email: 'customer@example.test', admin_email: 'admin@example.test',
+  }, { actor: { id: adminId }, source: 'v1' });
+  eventId = event.id;
+  await db('events').where({ id: eventId }).update({ slug });
+  revocation = require('../../src/utils/tokenRevocation');
+  apps = Object.fromEntries(['auth', 'adminAuth', 'customerAuth'].map(name => [
+    name, buildRouteApp('/', require(`../../src/routes/${name}`)),
+  ]));
+});
+afterEach(() => jest.restoreAllMocks());
+afterAll(async () => {
+  await require('../../src/services/serviceShutdown').stopServices();
+  if (cleanup) await cleanup();
+});
+
+it.each(cases)('%s%s revokes a no-expiry %s cookie session', async (route, path, type, cookie) => {
+  const token = sign(type);
+  const sessionApp = type === 'customer' ? apps.customerAuth : apps.auth;
+  const sessionPath = type === 'gallery' ? `/session?slug=${slug}` : '/session';
+  const session = () => request(sessionApp).get(sessionPath).set('Cookie', `${cookie}=${token}`);
+  const before = await session();
+  expect(before.status).toBe(200);
+  if (type !== 'customer') expect(before.body.valid).toBe(true);
+
+  const res = await request(apps[route]).post(path).set('Cookie', `${cookie}=${token}`).send({ slug });
+  expect(res.status).toBe(200);
+  expect(res.headers['set-cookie'].some(value => value.startsWith(`${cookie}=;`))).toBe(true);
+  await revocation.cleanupExpiredRevocations();
+  expect(await revocation.isTokenRevoked(jwt.decode(token))).toBe(true);
+  const after = await session();
+  if (type === 'customer') expect(after.status).toBe(401);
+  else expect(after.body.valid).toBe(false);
+});
+
+it.each(cases)('%s%s reports failed persistence for %s logout and clears its cookie', async (route, path, type, cookie) => {
+  const token = sign(type);
+  const realQuery = db.client.query;
+  jest.spyOn(db.client, 'query').mockImplementation(function (connection, query) {
+    if (/^insert into [`"]revoked_tokens[`"]/.test(query.sql)) {
+      return Promise.reject(new Error('simulated revocation write failure'));
+    }
+    return realQuery.call(this, connection, query);
+  });
+  const res = await request(apps[route]).post(path).set('Cookie', `${cookie}=${token}`).send({ slug });
+  expect(res.status).toBe(500);
+  expect(res.body.error).toBeTruthy();
+  expect(res.body.message).not.toBe('Logged out successfully');
+  expect(res.headers['set-cookie'].some(value => value.startsWith(`${cookie}=;`))).toBe(true);
+  expect(await revocation.isTokenRevoked(jwt.decode(token))).toBe(false);
+});

--- a/backend/__tests__/services/workerShutdown.test.js
+++ b/backend/__tests__/services/workerShutdown.test.js
@@ -1,0 +1,167 @@
+jest.mock('../../src/utils/logger', () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() }));
+
+describe.each(['backgroundProcessor', 'faceQueue'])('%s shutdown', name => {
+  let worker, db, processPhoto, featureEnabled, janitorUpdate, releases;
+  const prefix = name === 'faceQueue' ? 'FACE_PROCESSOR' : 'UPLOAD_PROCESSOR';
+  let previousEnv;
+  class SidecarUnavailableError extends Error {}
+
+  function deferred() {
+    let resolve;
+    const promise = new Promise(done => { resolve = done; });
+    releases.push(resolve);
+    return { promise, resolve };
+  }
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.useFakeTimers();
+    releases = [];
+    previousEnv = { ...process.env };
+    delete process.env[`${prefix}_DISABLED`];
+    process.env[`${prefix}_CONCURRENCY`] = '2';
+    process.env[`${prefix}_POLL_MS`] = '2000';
+    process.env.FACE_PROCESSOR_BACKOFF_MS = '30000';
+    processPhoto = jest.fn().mockResolvedValue({ status: 'skipped' });
+    featureEnabled = jest.fn().mockResolvedValue(true);
+    janitorUpdate = jest.fn().mockResolvedValue(0);
+    const chain = { where: jest.fn().mockReturnThis(), update: janitorUpdate };
+    db = jest.fn(() => chain);
+    db.client = { config: { client: 'pg' } };
+    // Claims and processing are controlled at the I/O boundary; the real
+    // workers, janitors, idle sleeps and stopServices run in every test.
+    db.transaction = jest.fn().mockResolvedValue(null);
+    jest.doMock('../../src/database/db', () => ({ db }));
+    jest.doMock('../../src/services/photoProcessor', () => ({ processPhoto }));
+    jest.doMock('../../src/services/faceProcessor', () => ({
+      processPhotoFaces: processPhoto, TransientSourceError: class extends Error {},
+    }));
+    jest.doMock('../../src/services/faceClient', () => ({ SidecarUnavailableError }));
+    jest.doMock('../../src/services/faceSettings', () => ({
+      isFeatureEnabled: featureEnabled, isEnabledForEvent: jest.fn().mockResolvedValue(false),
+    }));
+    worker = require(`../../src/services/${name}`);
+  });
+
+  afterEach(async () => {
+    releases.forEach(resolve => resolve());
+    const stopped = worker.stop();
+    // Also cleans up the original, non-interruptible implementation when a
+    // regression assertion fails; the test never needs to wait a real minute.
+    await jest.advanceTimersByTimeAsync(60000);
+    await stopped;
+    jest.useRealTimers();
+    process.env = previousEnv;
+  });
+
+  async function expectPromptStop(stop = () => worker.stop()) {
+    let done = false;
+    const stopped = stop().then(() => { done = true; });
+    await jest.advanceTimersByTimeAsync(0);
+    expect(done).toBe(true);
+    expect(jest.getTimerCount()).toBe(0);
+    await stopped;
+  }
+
+  it('wakes all idle workers and the minute-long janitor through stopServices', async () => {
+    worker.start();
+    await jest.advanceTimersByTimeAsync(0);
+    expect(jest.getTimerCount()).toBe(3);
+    // Confirm normal polling still runs before shutdown.
+    await jest.advanceTimersByTimeAsync(2000);
+    expect(db.transaction).toHaveBeenCalledTimes(4);
+    await expectPromptStop(() => require('../../src/services/serviceShutdown').stopServices());
+  });
+
+  it('wakes claim-error backoff and can start a fresh run after stopping', async () => {
+    db.transaction.mockRejectedValue(new Error('database unavailable'));
+    worker.start();
+    await jest.advanceTimersByTimeAsync(0);
+    await expectPromptStop();
+    db.transaction.mockResolvedValue(null);
+    worker.start();
+    await jest.advanceTimersByTimeAsync(0);
+    expect(jest.getTimerCount()).toBe(3);
+    await expectPromptStop();
+  });
+
+  it('drains active processing for every stop caller and prevents overlapping restarts', async () => {
+    const processing = deferred();
+    processPhoto.mockReturnValue(processing.promise);
+    db.transaction.mockResolvedValueOnce({ id: 1 });
+    worker.start();
+    await jest.advanceTimersByTimeAsync(0);
+    expect(processPhoto).toHaveBeenCalledWith(1);
+    let done = false;
+    const first = worker.stop();
+    expect(worker.stop()).toBe(first);
+    first.then(() => { done = true; });
+    worker.start();
+    await jest.advanceTimersByTimeAsync(0);
+    expect(done).toBe(false);
+    expect(db.transaction).toHaveBeenCalledTimes(2);
+    processing.resolve({ status: 'skipped' });
+    await expectPromptStop();
+    expect(done).toBe(true);
+    expect(db.transaction).toHaveBeenCalledTimes(2);
+  });
+
+  it('drains a claim already in flight without starting another poll', async () => {
+    const claim = deferred();
+    db.transaction.mockReturnValueOnce(claim.promise);
+    worker.start();
+    await jest.advanceTimersByTimeAsync(0);
+    const stopped = worker.stop();
+    claim.resolve({ id: 2 });
+    await expectPromptStop(() => stopped);
+    expect(processPhoto).toHaveBeenCalledWith(2);
+    expect(db.transaction).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not schedule new waits when pending database work finishes after stop', async () => {
+    const claim = deferred();
+    const janitor = deferred();
+    db.transaction.mockReturnValue(claim.promise);
+    janitorUpdate.mockReturnValue(janitor.promise);
+    worker.start();
+    await jest.advanceTimersByTimeAsync(0);
+    let done = false;
+    const stopped = worker.stop().then(() => { done = true; });
+    claim.resolve(null);
+    await jest.advanceTimersByTimeAsync(0);
+    expect(done).toBe(false);
+    janitor.resolve(0);
+    await expectPromptStop(() => stopped);
+  });
+
+  if (name === 'faceQueue') {
+    it('interrupts the ten-second sleep with faces disabled by default', async () => {
+      featureEnabled.mockResolvedValue(false);
+      worker.start();
+      await jest.advanceTimersByTimeAsync(0);
+      expect(db.transaction).not.toHaveBeenCalled();
+      expect(jest.getTimerCount()).toBe(3);
+      await expectPromptStop();
+    });
+
+    it('releases a claimed photo and interrupts the sidecar outage backoff', async () => {
+      db.transaction.mockResolvedValueOnce({ id: 3, event_id: 5 });
+      processPhoto.mockRejectedValue(new SidecarUnavailableError('offline'));
+      worker.start();
+      await jest.advanceTimersByTimeAsync(0);
+      expect(janitorUpdate).toHaveBeenCalledWith({ face_status: 'pending', face_started_at: null });
+      await expectPromptStop();
+      expect(worker.inFlightByEvent.size).toBe(0);
+    });
+
+    it('does not claim new work after a pending feature check resolves during shutdown', async () => {
+      const feature = deferred();
+      featureEnabled.mockReturnValue(feature.promise);
+      worker.start();
+      const stopped = worker.stop();
+      feature.resolve(true);
+      await expectPromptStop(() => stopped);
+      expect(db.transaction).not.toHaveBeenCalled();
+    });
+  }
+});

--- a/backend/__tests__/utils/tokenRevocation.forgery.test.js
+++ b/backend/__tests__/utils/tokenRevocation.forgery.test.js
@@ -20,7 +20,7 @@ jest.mock('../../src/database/db', () => {
   const dbFn = () => ({
     insert(row) {
       inserted.push(row);
-      return { onConflict: () => ({ ignore: async () => undefined }) };
+      return { onConflict: () => ({ ignore: async () => undefined, merge: async () => undefined }) };
     },
   });
   return { db: dbFn };

--- a/backend/migrations/core/211_revocations_without_expiry.js
+++ b/backend/migrations/core/211_revocations_without_expiry.js
@@ -1,0 +1,26 @@
+/** Non-expiring JWTs need revocation records that cleanup never removes. */
+exports.up = async function (knex) {
+  if (!await knex.schema.hasTable('revoked_tokens')) return;
+  if (!await knex.schema.hasColumn('revoked_tokens', 'expires_at')) return;
+  const column = await knex('revoked_tokens').columnInfo('expires_at');
+  if (!column.nullable) {
+    await knex.schema.alterTable('revoked_tokens', table => {
+      table.timestamp('expires_at').nullable().alter();
+    });
+  }
+};
+
+exports.down = async function (knex) {
+  if (!await knex.schema.hasTable('revoked_tokens')) return;
+  if (!await knex.schema.hasColumn('revoked_tokens', 'expires_at')) return;
+  // Refuse to discard permanent revocations or silently give them a TTL.
+  if (await knex('revoked_tokens').whereNull('expires_at').first()) {
+    throw new Error('Cannot roll back while permanent token revocations exist');
+  }
+  const column = await knex('revoked_tokens').columnInfo('expires_at');
+  if (column.nullable) {
+    await knex.schema.alterTable('revoked_tokens', table => {
+      table.timestamp('expires_at').notNullable().alter();
+    });
+  }
+};

--- a/backend/src/database/db.js
+++ b/backend/src/database/db.js
@@ -421,7 +421,7 @@ async function initializeDatabase() {
       table.integer('user_id').nullable(); // User who owned the token
       table.string('token_type', 20); // admin, gallery, etc.
       table.timestamp('revoked_at').defaultTo(db.fn.now());
-      table.timestamp('expires_at').notNullable(); // When token would have expired
+      table.timestamp('expires_at').nullable(); // NULL retains tokens without a known expiry
       table.string('reason', 100); // password_change, logout, compromised, etc.
       table.text('metadata'); // Additional JSON data
       

--- a/backend/src/routes/adminAuth.js
+++ b/backend/src/routes/adminAuth.js
@@ -182,16 +182,17 @@ router.post('/logout', adminAuth, handleAsync(async (req, res) => {
   // old header-only read skipped revocation entirely for cookie-based logout,
   // leaving the JWT valid until expiry while reporting a successful logout.
   const token = req.token;
+  clearAdminAuthCookie(res);
   if (token) {
     // End the in-memory session AND revoke the JWT (GHSA-cjqh) — the token
     // is otherwise valid until expiry, so photoAuth/adminAuth would keep
     // honouring it after logout. isTokenRevoked() checks this store.
     endSession(token);
     const { revokeToken } = require('../utils/tokenRevocation');
-    await revokeToken(token, 'logout');
+    if (!await revokeToken(token, 'logout')) {
+      throw new Error('Token revocation failed');
+    }
   }
-  // Clear the auth cookie so the browser stops sending the (now revoked) JWT.
-  clearAdminAuthCookie(res);
 
   // Log activity
   await logActivity('admin_logout',

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -356,7 +356,9 @@ router.post('/logout', async (req, res) => {
 
     if (token) {
       // Revoke the token so it can't be reused, then end the session
-      await revokeToken(token, 'user_logout');
+      if (!await revokeToken(token, 'user_logout')) {
+        throw new Error('Token revocation failed');
+      }
       endSession(token);
 
       try {
@@ -400,6 +402,8 @@ router.post('/logout', async (req, res) => {
 
     res.json({ message: 'Logged out successfully', ...(ssoLogoutUrl ? { ssoLogoutUrl } : {}) });
   } catch (error) {
+    clearAdminAuthCookie(res);
+    clearGalleryAuthCookies(res);
     errorResponse(res, error, 500, 'Logout failed');
   }
 });
@@ -714,11 +718,14 @@ router.post('/gallery/logout', async (req, res) => {
     const { slug } = req.body || {};
     const token = getGalleryTokenFromRequest(req, slug);
     if (token) {
-      await revokeToken(token, 'gallery_logout');
+      if (!await revokeToken(token, 'gallery_logout')) {
+        throw new Error('Token revocation failed');
+      }
     }
     clearGalleryAuthCookies(res, slug);
     res.json({ message: 'Logged out successfully' });
   } catch (error) {
+    clearGalleryAuthCookies(res, req.body?.slug);
     errorResponse(res, error, 500, 'Logout failed');
   }
 });

--- a/backend/src/routes/customerAuth.js
+++ b/backend/src/routes/customerAuth.js
@@ -181,7 +181,9 @@ router.post('/logout', async (req, res) => {
   try {
     const token = getCustomerTokenFromRequest(req);
     if (token) {
-      await revokeToken(token, 'user_logout');
+      if (!await revokeToken(token, 'user_logout')) {
+        throw new Error('Token revocation failed');
+      }
     }
     clearCustomerAuthCookie(res);
     res.json({ message: 'Logged out successfully' });

--- a/backend/src/services/backgroundProcessor.js
+++ b/backend/src/services/backgroundProcessor.js
@@ -29,6 +29,7 @@
 const os = require('os');
 const { db } = require('../database/db');
 const logger = require('../utils/logger');
+const { createInterruptibleSleep } = require('../utils/interruptibleSleep');
 const { processPhoto } = require('./photoProcessor');
 
 const POLL_INTERVAL_MS = parseInt(process.env.UPLOAD_PROCESSOR_POLL_MS || '1000', 10);
@@ -69,7 +70,9 @@ let running = false;
 let workerHandles = [];
 let janitorHandle = null;
 
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+let waits = null;
+let stopping = null;
+const sleep = ms => waits.sleep(ms);
 
 function isPostgres() {
   const c = db.client.config.client;
@@ -175,12 +178,13 @@ async function janitorLoop() {
 }
 
 function start() {
-  if (running) return;
+  if (running || stopping) return;
   if (process.env.UPLOAD_PROCESSOR_DISABLED === 'true') {
     logger.info('backgroundProcessor: disabled via UPLOAD_PROCESSOR_DISABLED');
     return;
   }
 
+  waits = createInterruptibleSleep();
   running = true;
   workerHandles = [];
   for (let i = 0; i < CONCURRENCY; i++) {
@@ -199,12 +203,20 @@ function start() {
   );
 }
 
-async function stop() {
-  if (!running) return;
+function stop() {
+  if (stopping) return stopping;
+  if (!running) return Promise.resolve();
   running = false;
-  await Promise.all([...workerHandles, janitorHandle].filter(Boolean));
-  workerHandles = [];
-  janitorHandle = null;
+  // Interrupt idle/backoff waits only. Claims, processing and janitor work
+  // already in flight still drain before the database can be closed.
+  waits.cancel();
+  stopping = Promise.all([...workerHandles, janitorHandle].filter(Boolean)).finally(() => {
+    workerHandles = [];
+    janitorHandle = null;
+    waits = null;
+    stopping = null;
+  });
+  return stopping;
 }
 
 module.exports = { start, stop, claimNextPhoto };

--- a/backend/src/services/faceQueue.js
+++ b/backend/src/services/faceQueue.js
@@ -28,6 +28,7 @@
 
 const { db } = require('../database/db');
 const logger = require('../utils/logger');
+const { createInterruptibleSleep } = require('../utils/interruptibleSleep');
 const { processPhotoFaces } = require('./faceProcessor');
 const { SidecarUnavailableError } = require('./faceClient');
 const { TransientSourceError } = require('./faceProcessor');
@@ -220,7 +221,9 @@ let running = false;
 let workerHandles = [];
 let janitorHandle = null;
 
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+let waits = null;
+let stopping = null;
+const sleep = ms => waits.sleep(ms);
 
 function isPostgres() {
   const c = db.client.config.client;
@@ -288,6 +291,8 @@ async function workerLoop(workerIdx) {
       await sleep(POLL_INTERVAL_MS * 5);
       continue;
     }
+
+    if (!running) break;
 
     let claimed;
     try {
@@ -407,12 +412,13 @@ async function janitorLoop() {
 }
 
 function start() {
-  if (running) return;
+  if (running || stopping) return;
   if (process.env.FACE_PROCESSOR_DISABLED === 'true') {
     logger.info('faceQueue: disabled via FACE_PROCESSOR_DISABLED');
     return;
   }
 
+  waits = createInterruptibleSleep();
   running = true;
   workerHandles = [];
   for (let i = 0; i < CONCURRENCY; i++) {
@@ -432,12 +438,20 @@ function start() {
   );
 }
 
-async function stop() {
-  if (!running) return;
+function stop() {
+  if (stopping) return stopping;
+  if (!running) return Promise.resolve();
   running = false;
-  await Promise.all([...workerHandles, janitorHandle].filter(Boolean));
-  workerHandles = [];
-  janitorHandle = null;
+  // Interrupt idle/backoff waits only. Claims, processing and janitor work
+  // already in flight still drain before the database can be closed.
+  waits.cancel();
+  stopping = Promise.all([...workerHandles, janitorHandle].filter(Boolean)).finally(() => {
+    workerHandles = [];
+    janitorHandle = null;
+    waits = null;
+    stopping = null;
+  });
+  return stopping;
 }
 
 // drainConsolidation, touchedEvents and consolidationRetryAt are exported for

--- a/backend/src/utils/interruptibleSleep.js
+++ b/backend/src/utils/interruptibleSleep.js
@@ -1,0 +1,25 @@
+/** A run owns its waits; cancelling wakes every waiter and clears its timer. */
+function createInterruptibleSleep() {
+  let cancelled = false;
+  const waiters = new Set();
+  return {
+    sleep(ms) {
+      if (cancelled) return Promise.resolve();
+      return new Promise(resolve => {
+        const finish = () => {
+          clearTimeout(timer);
+          waiters.delete(finish);
+          resolve();
+        };
+        const timer = setTimeout(finish, ms);
+        waiters.add(finish);
+      });
+    },
+    cancel() {
+      cancelled = true;
+      for (const finish of waiters) finish();
+    },
+  };
+}
+
+module.exports = { createInterruptibleSleep };

--- a/backend/src/utils/tokenRevocation.js
+++ b/backend/src/utils/tokenRevocation.js
@@ -6,6 +6,7 @@
 const jwt = require('jsonwebtoken');
 const { db } = require('../database/db');
 const logger = require('./logger');
+const MAX_SQL_EXPIRY_SECONDS = Date.parse('9999-12-31T23:59:59Z') / 1000;
 
 /**
  * Add a token to the revocation list
@@ -52,20 +53,28 @@ async function revokeToken(token, reason, metadata = {}) {
     // undefined/string slip through and cause an INSERT type error.
     const userIdNumeric = Number.isInteger(payload.id) ? payload.id : null;
 
-    // onConflict.ignore: revoking an already-revoked token is a no-op,
-    // not an error. Hits the unique (token_id) index when the same JWT
-    // is logged out twice (e.g. duplicate /logout from two tabs, or a
-    // session-expiry path that races with an explicit logout). The
-    // previous insert was authoritative; nothing to do.
-    await db('revoked_tokens').insert({
+    // JWT permits a missing exp. Keep that revocation permanently: an
+    // arbitrary fallback TTL would make the token usable again after cleanup.
+    // Retain unrepresentable expiries too, using the common SQL/ISO date range.
+    const expiresAt = Number.isFinite(payload.exp)
+      && payload.exp >= 0 && payload.exp <= MAX_SQL_EXPIRY_SECONDS
+      ? new Date(Math.ceil(payload.exp * 1000)).toISOString()
+      : null;
+
+    // Duplicate logouts are idempotent. A permanent revocation must also
+    // upgrade an existing expiring entry with the same legacy key or jti;
+    // logging out an expiring token must never shorten that retention again.
+    const insert = db('revoked_tokens').insert({
       token_id: buildTokenId(payload),
       user_id: userIdNumeric,
       token_type: payload.type,
       revoked_at: new Date().toISOString(),
-      expires_at: new Date(payload.exp * 1000).toISOString(),
+      expires_at: expiresAt,
       reason,
       metadata: JSON.stringify(metadata)
-    }).onConflict('token_id').ignore();
+    }).onConflict('token_id');
+    if (expiresAt === null) await insert.merge({ expires_at: null });
+    else await insert.ignore();
 
     logger.info('Token revoked', {
       userId: payload.id ?? payload.customerId ?? null,
@@ -131,6 +140,7 @@ async function revokeAllUserTokens(userId, reason) {
 async function cleanupExpiredRevocations() {
   try {
     const deleted = await db('revoked_tokens')
+      .whereNotNull('expires_at')
       .where('expires_at', '<', new Date().toISOString())
       .delete();
     


### PR DESCRIPTION
## Description

Fixes both remaining findings from the [last QA round on #1357](https://github.com/PicPeak/picpeak/pull/1357#issuecomment-5584838616).

The photo and face workers previously waited on 10–60 second idle timers during shutdown, exceeding the server's 8 second deadline. Both pools now cancel their idle, janitor and retry waits immediately while draining database operations and photo processing already in flight. Concurrent stop callers share the drain, and a new worker run cannot overlap a stopping run.

A correctly signed JWT without `exp` previously failed revocation with `RangeError` while logout reported success. Such tokens now receive permanent revocation records. Cleanup preserves these records, including when an expiring record already uses the same legacy key or `jti`. All four logout handlers check revocation results and report failure while clearing cookies if persistence fails.

## Type of change

- [x] Bug fix

## How Has This Been Tested?

- [x] Full backend Jest suite: **317 suites passed; 3,451 tests passed, 1 skipped**, with PostgreSQL integration tests enabled.
- [x] Worker regression tests cover idle polling, faces disabled, claim errors, sidecar backoff, pending database work, active processing, concurrent stops and restart isolation. Five targeted shutdown cases fail against the original worker implementations.
- [x] SQLite and PostgreSQL tests cover migration upgrades, repeat runs, rollback protection, permanent revocations, legacy keys, duplicate logout and normal expiry cleanup. HTTP route tests cover all four logout handlers and simulated revocation write failures; signature-forgery tests remain passing.
- [x] Real Docker backend + PostgreSQL 16: three shutdown/restart runs finished in **0.216s, 0.226s and 0.184s**, each with exit code 0 and both worker services enabled, with faces off. No forced-exit path occurred.
- [x] Real Docker HTTP check: an authenticated no-expiry admin cookie was valid before logout, logout returned 200, and replaying the cookie returned an invalid session.
- [x] ESLint passed for all changed application files; `git diff --check` passed.

Backend tests can be reproduced with `npm test -- --ci` from `backend/`, setting `PICPEAK_PG_TEST_URL` to an isolated test database as in CI. Local validation used Node.js 22.20.0, SQLite and PostgreSQL 16.

## Compatibility

Migration `211_revocations_without_expiry.js` allows `revoked_tokens.expires_at` to be NULL for permanent revocations and preserves existing records. Its rollback refuses to remove that support while permanent revocations exist. Logout now returns HTTP 500 when revocation fails, instead of falsely reporting success. Active jobs remain subject to the configured shutdown deadline.

## Checklist

- [x] Self-reviewed the changes and added behavioral regression coverage.
- [x] No Markdown files or private task reports are included in this PR.
