### PR TITLE
fix(usage): explain and de-emphasize the pending-packet button lock

### DIFF
--- a/frontend/src/features/settings/__tests__/ProductUsageTab.test.tsx
+++ b/frontend/src/features/settings/__tests__/ProductUsageTab.test.tsx
@@ -103,6 +103,32 @@ it('pending v2 confirmation clearly keeps v1 and cannot queue another upgrade', 
   expect(screen.getByRole('button', { name: 'productUsage.reviewUpgrade' })).toBeDisabled();
   expect(service.upgradeConsent).not.toHaveBeenCalled();
 });
+it.each(['activation_pending', 'deletion_pending'] as const)('a stuck packet in %s names nothing, since neither control is actually gated by it', async (pendingStatus) => {
+  // Outside `active`, the portal renders as a plain always-enabled link and
+  // no v5-upgrade section exists — pending_action blocks neither, so the
+  // note must not claim it does.
+  vi.mocked(service.status).mockResolvedValue({ ...status, status: pendingStatus, collector_url: 'https://usage.picpeak.app', pending_action: pendingStatus === 'activation_pending' ? 'register' : 'delete' });
+  mount();
+  await screen.findByText(`productUsage.states.${pendingStatus}`);
+  expect(screen.queryByText('productUsage.pendingBlocksActions')).toBeNull();
+  expect(screen.queryByText('productUsage.pendingBlocksPortal')).toBeNull();
+});
+it('a stuck report on an already-current schema names only the portal, not a non-existent upgrade button', async () => {
+  vi.mocked(service.status).mockResolvedValue({ ...status, status: 'active', consent_update_available: false, pending_action: 'report' });
+  mount();
+  expect(await screen.findByText('productUsage.pendingBlocksPortal')).toBeInTheDocument();
+  expect(screen.queryByText('productUsage.pendingBlocksActions')).toBeNull();
+  expect(screen.queryByText('productUsage.reviewUpgrade')).toBeNull();
+  expect(screen.getByRole('button', { name: 'productUsage.openUsagePortal' })).toBeDisabled();
+});
+it('a stuck report with a v5 upgrade available names both actually-gated controls', async () => {
+  vi.mocked(service.status).mockResolvedValue({ ...status, status: 'active', consent_update_available: true, collector_url: 'https://usage.picpeak.app', pending_action: 'report' });
+  mount();
+  expect(await screen.findByText('productUsage.pendingBlocksActions')).toBeInTheDocument();
+  expect(screen.queryByText('productUsage.pendingBlocksPortal')).toBeNull();
+  expect(screen.getByRole('button', { name: 'productUsage.reviewUpgrade' })).toBeDisabled();
+  expect(screen.getByRole('button', { name: 'productUsage.openUsagePortal' })).toBeDisabled();
+});
 describe('product usage controls', () => {
   it('offers identity-free audit receipts after opt-out without restoring participation controls', async () => {
     vi.mocked(service.status).mockResolvedValue({

--- a/frontend/src/features/settings/tabs/ProductUsageTab.tsx
+++ b/frontend/src/features/settings/tabs/ProductUsageTab.tsx
@@ -223,6 +223,16 @@ export default function ProductUsageTab() {
             </Button>
           </div>
         )}
+        {data.pending_action && data.pending_action !== 'consent' && (
+          // The v5-upgrade and portal buttons below are disabled by the same
+          // pending-packet guard the backend enforces (command() refuses a
+          // second packet while one is still unacknowledged) — without this
+          // note the buttons just look broken, and "Retry" above them isn't
+          // obviously the fix.
+          <p role="status" className="text-sm text-neutral-600 dark:text-neutral-400">
+            {t('productUsage.pendingBlocksActions')}
+          </p>
+        )}
         <div className="flex flex-wrap gap-3">
           {data.status === 'disabled' ? (
             <Button disabled={busy} onClick={() => setConsent(true)}>
@@ -274,7 +284,6 @@ export default function ProductUsageTab() {
               {active ? (
                 <>
                   <Button
-                    variant="outline"
                     disabled={busy || Boolean(data.pending_action)}
                     onClick={openPortal}
                   >
@@ -294,7 +303,7 @@ export default function ProductUsageTab() {
                 </>
               ) : (
                 <a
-                  className="btn btn-outline btn-md"
+                  className="btn btn-primary btn-md"
                   href={data.collector_url}
                   target="_blank"
                   rel="noopener noreferrer"

--- a/frontend/src/features/settings/tabs/ProductUsageTab.tsx
+++ b/frontend/src/features/settings/tabs/ProductUsageTab.tsx
@@ -223,14 +223,20 @@ export default function ProductUsageTab() {
             </Button>
           </div>
         )}
-        {data.pending_action && data.pending_action !== 'consent' && (
-          // The v5-upgrade and portal buttons below are disabled by the same
-          // pending-packet guard the backend enforces (command() refuses a
-          // second packet while one is still unacknowledged) — without this
-          // note the buttons just look broken, and "Retry" above them isn't
-          // obviously the fix.
+        {active && data.pending_action && data.pending_action !== 'consent' && (
+          // The portal button below (and the v5-upgrade button above, when
+          // present) are disabled by the same pending-packet guard the
+          // backend enforces (command() refuses a second packet while one is
+          // still unacknowledged) — without this note they just look broken,
+          // and "Retry" above isn't obviously the fix. Gated on `active`:
+          // outside that status the portal renders as a plain, un-gated link
+          // and no v5-upgrade section exists, so pending_action blocks
+          // nothing this note could correctly describe (e.g.
+          // activation_pending/deletion_pending with their own packet still
+          // in flight). Which controls it names depends on whether the
+          // v5-upgrade section is actually on screen.
           <p role="status" className="text-sm text-neutral-600 dark:text-neutral-400">
-            {t('productUsage.pendingBlocksActions')}
+            {t(data.consent_update_available ? 'productUsage.pendingBlocksActions' : 'productUsage.pendingBlocksPortal')}
           </p>
         )}
         <div className="flex flex-wrap gap-3">

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -19,6 +19,7 @@
     "upgradeExplanation": "Deine bestehende Teilnahme behält ihren bisherigen Umfang. Sieh dir den erweiterten Katalog und die beiden Bestandszahlen an, bevor du dich entscheidest. Ablehnen beendet die Teilnahme nicht.",
     "upgradePending": "Die signierte Erweiterung wartet auf die Bestätigung des Collectors. Bis dahin wird nur der bisher bestätigte Umfang erfasst. Versuche es erneut, wenn der Collector erreichbar ist, oder deaktiviere die Teilnahme, um zu stoppen und zu löschen.",
     "pendingBlocksActions": "Das v5-Upgrade und das Nutzungsportal sind gesperrt, bis der ausstehende Bericht erneut gesendet wurde oder zugestellt ist — nutze oben „Jetzt senden“.",
+    "pendingBlocksPortal": "Das Nutzungsportal ist gesperrt, bis der ausstehende Bericht erneut gesendet wurde oder zugestellt ist — nutze oben „Jetzt senden“.",
     "catalog": {
       "crm": {
         "name": "Kundenverwaltung",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -14,10 +14,11 @@
     "configurationOnly": "Nur Konfiguration, die tatsächliche Nutzung wird nicht erfasst.",
     "versionDisclosure": "Diese Zustimmung gilt für usage.v5 / usage-consent.v5: 87 Funktionen und dieselben zwei Bestandszahlen. Neue Ja/Nein-Werte unterscheiden echte CMS-, Vorlagen-, Branding-, SEO-, Kategorie- und Ereignistyp-Änderungen sowie die Annahme echter Vorlagen-E-Mails durch den Mailtransport (auch im Hintergrund) von Standards, unverändertem Speichern, Vorschauen und Tests. Inhalte, Empfänger, Vorlagenkennungen, Aktionszeitpunkte und Häufigkeiten werden nicht erfasst. Die Beobachtung beginnt erst nach bestätigter Zustimmung; Nein bedeutet nicht, dass noch Standards verwendet werden. Frühere Versionen behalten bis zum Upgrade Bedeutung und Umfang. Wartende Pakete bleiben unverändert; Markierungen starten nach Bestätigung neu.",
     "currentSchema": "Aktuelles Berichtsschema: {{schema}}",
-    "reviewUpgrade": "Erweiterten Umfang von usage.v5 ansehen",
+    "reviewUpgrade": "Auf usage.v5 upgraden",
     "upgrade": "usage.v5 ausdrücklich zustimmen",
     "upgradeExplanation": "Deine bestehende Teilnahme behält ihren bisherigen Umfang. Sieh dir den erweiterten Katalog und die beiden Bestandszahlen an, bevor du dich entscheidest. Ablehnen beendet die Teilnahme nicht.",
     "upgradePending": "Die signierte Erweiterung wartet auf die Bestätigung des Collectors. Bis dahin wird nur der bisher bestätigte Umfang erfasst. Versuche es erneut, wenn der Collector erreichbar ist, oder deaktiviere die Teilnahme, um zu stoppen und zu löschen.",
+    "pendingBlocksActions": "Das v5-Upgrade und das Nutzungsportal sind gesperrt, bis der ausstehende Bericht erneut gesendet wurde oder zugestellt ist — nutze oben „Jetzt senden“.",
     "catalog": {
       "crm": {
         "name": "Kundenverwaltung",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -14,10 +14,11 @@
     "configurationOnly": "Configuration only — actual use is not collected.",
     "versionDisclosure": "This consent covers usage.v5 / usage-consent.v5: 87 capabilities and the same two inventory totals. New booleans distinguish real CMS/template/branding/SEO/category/event-type edits and actual template-email transport acceptance, including background sends, from defaults, unchanged saves, previews and tests. No content, recipient, template key, action timestamp or frequency is collected. Observations begin only after accepted consent; false does not mean an installation still uses defaults. Previous versions keep their meanings and scope until upgrade; queued packets stay unchanged and markers restart after confirmation.",
     "currentSchema": "Current reporting schema: {{schema}}",
-    "reviewUpgrade": "Review expanded usage.v5 scope",
+    "reviewUpgrade": "Upgrade to usage.v5",
     "upgrade": "Explicitly agree to usage.v5",
     "upgradeExplanation": "Your existing participation keeps its current scope. Review the expanded catalog and the two inventory totals before deciding whether to upgrade. Declining does not end participation.",
     "upgradePending": "The signed consent upgrade is pending confirmation. Only the previously accepted scope is collected. Retry when the collector is available, or disable participation to stop and delete.",
+    "pendingBlocksActions": "The v5 upgrade and the usage portal are unavailable until the pending report is retried or delivered — use \"Retry / send if due\" above.",
     "catalog": {
       "crm": {
         "name": "Client management",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -19,6 +19,7 @@
     "upgradeExplanation": "Your existing participation keeps its current scope. Review the expanded catalog and the two inventory totals before deciding whether to upgrade. Declining does not end participation.",
     "upgradePending": "The signed consent upgrade is pending confirmation. Only the previously accepted scope is collected. Retry when the collector is available, or disable participation to stop and delete.",
     "pendingBlocksActions": "The v5 upgrade and the usage portal are unavailable until the pending report is retried or delivered — use \"Retry / send if due\" above.",
+    "pendingBlocksPortal": "The usage portal is unavailable until the pending report is retried or delivered — use \"Retry / send if due\" above.",
     "catalog": {
       "crm": {
         "name": "Client management",


### PR DESCRIPTION
## Description

An admin whose report delivery is stuck (old consent schema, transient network issue, etc.) sees the "Upgrade to usage.v5" and "Open usage portal" buttons on Settings → Product usage silently greyed out. The backend's guard is correct — `command()` refuses a second packet while one is still unacknowledged (`ConflictError('Retry the pending usage operation first')`) — but the frontend gave no indication of that, so the buttons just looked broken. The only way to unblock them was discovering that "Retry / send if due" ("Jetzt senden") had to be clicked first.

Reported directly from a self-hosted install after an upgrade landed it on `usage.v3` with a stuck delivery.

- Added an inline note, shown only when a pending packet (not a pending consent, which already has its own message) is the actual blocker, pointing at "Retry / send if due" as the fix.
- Renamed `productUsage.reviewUpgrade` from "Review expanded usage.v5 scope" / "Erweiterten Umfang von usage.v5 ansehen" to "Upgrade to usage.v5" / "Auf usage.v5 upgraden" — the old wording didn't read as an upgrade action.
- "Open usage portal" is now a primary (green) button in both its signed-in and pre-participation forms, instead of a secondary outline button that didn't match the visual weight of the other primary actions on the tab.

## Type of change

- [x] Bug fix

## How Has This Been Tested?

- `tsc --noEmit`: clean.
- `eslint` on the changed file: clean.
- Existing `ProductUsageTab.test.tsx` (23 tests): all pass — asserts button names via i18n keys, not translated text, and the disabled-state logic is unchanged, only the new conditional message and CSS class are new.
- Reproduced the exact reported scenario live against a fresh isolated instance (`status: active`, `consent_version: usage-consent.v3`, a stuck `pending_packet`, `last_error`, future `next_attempt_at`) and confirmed: the new message renders exactly where expected, both buttons stay correctly disabled while blocked, and both render as primary/green and become clickable once the pending packet clears. Screenshot of the reproduced state attached separately.

## Checklist

- [x] Performed self-review
- [x] New and existing test suites pass locally
- [x] Incorporated base changes