### PR TITLE
fix(backend): require actor to hold every permission of a role they grant

### DIFF
--- a/backend/__tests__/services/userManagementService.roleGrantGuard.test.js
+++ b/backend/__tests__/services/userManagementService.roleGrantGuard.test.js
@@ -1,0 +1,138 @@
+/**
+ * Privilege-escalation guard for PUT /api/admin/users/:id (GHSA-rv8w-m6mx-7j4q).
+ *
+ * updateAdminUser's role-change path previously enforced only:
+ *   (a) non-super_admin actors can't grant the super_admin role
+ *   (b) no self-role-update / demoting the last super_admin
+ * It never checked whether the ACTOR's own permission set covers the
+ * permissions carried by the role being granted — so an admin holding
+ * only `users.edit` could hand any other admin a role (including the
+ * built-in `admin` role) carrying far more permissions than the actor
+ * itself held.
+ *
+ * The fix reuses assertActorMayGrant() — the same containment already
+ * applied to roles.manage (see adminRolesGuards.test.js) — inside the
+ * role_id branch of updateAdminUser.
+ */
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+process.env.NODE_ENV = 'test';
+process.env.TEST_DATABASE_PATH = path.join(
+  fs.mkdtempSync(path.join(os.tmpdir(), 'picpeak-rolegrantguard-')), 'db.sqlite',
+);
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'rolegrantguard-test-secret';
+process.env.STORAGE_PATH = fs.mkdtempSync(path.join(os.tmpdir(), 'picpeak-rolegrantguard-storage-'));
+
+const { bootCrmDb, seedMinimal, assignAdminRole } = require('../integration/helpers/crmDb');
+const svc = require('../../src/services/userManagementService');
+const { clearPermissionCache } = require('../../src/middleware/permissions');
+
+describe('updateAdminUser — role-grant privilege-escalation guard (GHSA-rv8w-m6mx-7j4q)', () => {
+  let db; let cleanup;
+  let superId;
+  let limitedRoleId; let limitedId; // holds only users.edit + events.view
+  let powerfulRoleId; // carries settings.banking, which limitedId does NOT hold
+  let modestRoleId; // carries only events.view, a subset of what limitedId holds
+  let targetId; // account whose role limitedId will try to change
+
+  beforeAll(async () => {
+    ({ db, cleanup } = await bootCrmDb());
+    ({ adminId: superId } = await seedMinimal(db));
+    await assignAdminRole(db, superId, 'super_admin');
+
+    // The attacker in GHSA-rv8w-m6mx-7j4q: users.edit only, nothing else.
+    const limitedRole = await svc.createRole(
+      { name: 'limited_user_editor', permissions: ['users.edit', 'events.view'] },
+      superId,
+    );
+    limitedRoleId = limitedRole.id;
+    const limitedIns = await db('admin_users').insert({
+      username: 'limited', email: 'limited@example.com', password_hash: 'x',
+      role_id: limitedRoleId, must_change_password: false, created_at: new Date(),
+    }).returning('id');
+    limitedId = limitedIns[0]?.id ?? limitedIns[0];
+
+    // A role carrying a permission the limited actor does not hold.
+    const powerfulRole = await svc.createRole(
+      { name: 'powerful_role', permissions: ['users.edit', 'settings.banking'] },
+      superId,
+    );
+    powerfulRoleId = powerfulRole.id;
+
+    // A role whose permissions ARE a subset of what the limited actor holds.
+    const modestRole = await svc.createRole(
+      { name: 'modest_role', permissions: ['events.view'] },
+      superId,
+    );
+    modestRoleId = modestRole.id;
+
+    clearPermissionCache();
+  }, 120000);
+
+  afterAll(async () => { if (cleanup) await cleanup(); });
+
+  beforeEach(async () => {
+    // Fresh target for every test, role reset to modestRole so role-change
+    // assertions always start from a known baseline.
+    const existing = await db('admin_users').where({ username: 'target' }).first();
+    if (existing) {
+      targetId = existing.id;
+      await db('admin_users').where({ id: targetId }).update({ role_id: modestRoleId });
+    } else {
+      const ins = await db('admin_users').insert({
+        username: 'target', email: 'target@example.com', password_hash: 'x',
+        role_id: modestRoleId, must_change_password: false, created_at: new Date(),
+      }).returning('id');
+      targetId = ins[0]?.id ?? ins[0];
+    }
+  });
+
+  it('refuses to let an admin grant a role carrying permissions the admin lacks', async () => {
+    await expect(
+      svc.updateAdminUser(
+        targetId,
+        { role_id: powerfulRoleId },
+        limitedId,
+        { roleName: 'limited_user_editor' },
+      ),
+    ).rejects.toThrow(/only grant permissions your own role/i);
+
+    // Target's role must be unchanged.
+    const row = await db('admin_users').where({ id: targetId }).first();
+    expect(row.role_id).toBe(modestRoleId);
+  });
+
+  it('refuses to let an admin grant the built-in admin role beyond its own permissions', async () => {
+    const adminRole = await db('roles').where({ name: 'admin' }).first();
+    await expect(
+      svc.updateAdminUser(
+        targetId,
+        { role_id: adminRole.id },
+        limitedId,
+        { roleName: 'limited_user_editor' },
+      ),
+    ).rejects.toThrow(/only grant permissions your own role/i);
+  });
+
+  it('allows an admin to grant a role whose permissions it already holds', async () => {
+    const updated = await svc.updateAdminUser(
+      targetId,
+      { role_id: limitedRoleId },
+      limitedId,
+      { roleName: 'limited_user_editor' },
+    );
+    expect(updated.role_id).toBe(limitedRoleId);
+  });
+
+  it('super_admin can still grant any role, including one carrying more permissions than a limited actor holds', async () => {
+    const updated = await svc.updateAdminUser(
+      targetId,
+      { role_id: powerfulRoleId },
+      superId,
+      { roleName: 'super_admin' },
+    );
+    expect(updated.role_id).toBe(powerfulRoleId);
+  });
+});

--- a/backend/__tests__/services/userManagementService.roleGrantGuard.test.js
+++ b/backend/__tests__/services/userManagementService.roleGrantGuard.test.js
@@ -1,5 +1,6 @@
 /**
- * Privilege-escalation guard for PUT /api/admin/users/:id (GHSA-rv8w-m6mx-7j4q).
+ * Privilege-escalation guard for PUT /api/admin/users/:id and
+ * POST /api/admin/users/invite (GHSA-rv8w-m6mx-7j4q).
  *
  * updateAdminUser's role-change path previously enforced only:
  *   (a) non-super_admin actors can't grant the super_admin role
@@ -10,9 +11,21 @@
  * built-in `admin` role) carrying far more permissions than the actor
  * itself held.
  *
+ * createInvitation() had the identical gap: it only ever blocked
+ * granting super_admin, so an admin holding only `users.create` could
+ * invite a brand-new admin into any other role — including one carrying
+ * far more permissions than the inviter itself held — via
+ * POST /admin/users/invite.
+ *
  * The fix reuses assertActorMayGrant() — the same containment already
- * applied to roles.manage (see adminRolesGuards.test.js) — inside the
- * role_id branch of updateAdminUser.
+ * applied to roles.manage (see adminRolesGuards.test.js) — inside both
+ * updateAdminUser's role_id branch and createInvitation().
+ *
+ * Both describe blocks below share a single bootCrmDb() call: the
+ * `db` module (`src/database/db.js`) is a singleton keyed off
+ * TEST_DATABASE_PATH at first require, and bootCrmDb's own comment
+ * warns that a second call after the first's cleanup() destroys the
+ * pool, leaving "Unable to acquire a connection" for every later query.
  */
 const path = require('path');
 const fs = require('fs');
@@ -29,19 +42,25 @@ const { bootCrmDb, seedMinimal, assignAdminRole } = require('../integration/help
 const svc = require('../../src/services/userManagementService');
 const { clearPermissionCache } = require('../../src/middleware/permissions');
 
+let db; let cleanup;
+let superId;
+
+beforeAll(async () => {
+  ({ db, cleanup } = await bootCrmDb());
+  ({ adminId: superId } = await seedMinimal(db));
+  await assignAdminRole(db, superId, 'super_admin');
+  clearPermissionCache();
+}, 120000);
+
+afterAll(async () => { if (cleanup) await cleanup(); });
+
 describe('updateAdminUser — role-grant privilege-escalation guard (GHSA-rv8w-m6mx-7j4q)', () => {
-  let db; let cleanup;
-  let superId;
   let limitedRoleId; let limitedId; // holds only users.edit + events.view
   let powerfulRoleId; // carries settings.banking, which limitedId does NOT hold
   let modestRoleId; // carries only events.view, a subset of what limitedId holds
   let targetId; // account whose role limitedId will try to change
 
   beforeAll(async () => {
-    ({ db, cleanup } = await bootCrmDb());
-    ({ adminId: superId } = await seedMinimal(db));
-    await assignAdminRole(db, superId, 'super_admin');
-
     // The attacker in GHSA-rv8w-m6mx-7j4q: users.edit only, nothing else.
     const limitedRole = await svc.createRole(
       { name: 'limited_user_editor', permissions: ['users.edit', 'events.view'] },
@@ -70,8 +89,6 @@ describe('updateAdminUser — role-grant privilege-escalation guard (GHSA-rv8w-m
 
     clearPermissionCache();
   }, 120000);
-
-  afterAll(async () => { if (cleanup) await cleanup(); });
 
   beforeEach(async () => {
     // Fresh target for every test, role reset to modestRole so role-change
@@ -134,5 +151,85 @@ describe('updateAdminUser — role-grant privilege-escalation guard (GHSA-rv8w-m
       { roleName: 'super_admin' },
     );
     expect(updated.role_id).toBe(powerfulRoleId);
+  });
+});
+
+describe('createInvitation — role-grant privilege-escalation guard (GHSA-rv8w-m6mx-7j4q)', () => {
+  let limitedRoleId; let limitedId; // holds only users.create + events.view
+  let powerfulRoleId; // carries settings.banking, which limitedId does NOT hold
+  let modestRoleId; // carries only events.view, a subset of what limitedId holds
+  let inviteCounter = 0;
+
+  beforeAll(async () => {
+    const limitedRole = await svc.createRole(
+      { name: 'limited_inviter', permissions: ['users.create', 'events.view'] },
+      superId,
+    );
+    limitedRoleId = limitedRole.id;
+    const limitedIns = await db('admin_users').insert({
+      username: 'limited_inviter', email: 'limited_inviter@example.com', password_hash: 'x',
+      role_id: limitedRoleId, must_change_password: false, created_at: new Date(),
+    }).returning('id');
+    limitedId = limitedIns[0]?.id ?? limitedIns[0];
+
+    const powerfulRole = await svc.createRole(
+      { name: 'powerful_invite_role', permissions: ['users.create', 'settings.banking'] },
+      superId,
+    );
+    powerfulRoleId = powerfulRole.id;
+
+    const modestRole = await svc.createRole(
+      { name: 'modest_invite_role', permissions: ['events.view'] },
+      superId,
+    );
+    modestRoleId = modestRole.id;
+
+    clearPermissionCache();
+  }, 120000);
+
+  function nextEmail() {
+    inviteCounter += 1;
+    return `invitee-${inviteCounter}@example.com`;
+  }
+
+  it('refuses to let an admin invite someone into a role carrying permissions the admin lacks', async () => {
+    await expect(
+      svc.createInvitation({
+        email: nextEmail(),
+        roleId: powerfulRoleId,
+        invitedById: limitedId,
+        inviterRoleName: 'limited_inviter',
+      }),
+    ).rejects.toThrow(/only grant permissions your own role/i);
+  });
+
+  it('allows an admin to invite someone into a role whose permissions it already holds', async () => {
+    const invitation = await svc.createInvitation({
+      email: nextEmail(),
+      roleId: limitedRoleId,
+      invitedById: limitedId,
+      inviterRoleName: 'limited_inviter',
+    });
+    expect(invitation.role).toBeTruthy();
+  });
+
+  it('allows an admin to invite someone into a role that is a subset of its own permissions', async () => {
+    const invitation = await svc.createInvitation({
+      email: nextEmail(),
+      roleId: modestRoleId,
+      invitedById: limitedId,
+      inviterRoleName: 'limited_inviter',
+    });
+    expect(invitation.role).toBeTruthy();
+  });
+
+  it('super_admin can still invite into any role, including one carrying more permissions than a limited actor holds', async () => {
+    const invitation = await svc.createInvitation({
+      email: nextEmail(),
+      roleId: powerfulRoleId,
+      invitedById: superId,
+      inviterRoleName: 'super_admin',
+    });
+    expect(invitation.role).toBeTruthy();
   });
 });

--- a/backend/src/services/userManagementService.js
+++ b/backend/src/services/userManagementService.js
@@ -48,6 +48,16 @@ async function createInvitation({ email, roleId, invitedById, inviterRoleName })
     throw new ValidationError('Only Super Admins can invite new Super Admins');
   }
 
+  // Privilege-escalation guard (GHSA-rv8w-m6mx-7j4q): holding `users.create`
+  // must not let an actor invite someone into a role carrying permissions
+  // they don't themselves have — same containment updateAdminUser already
+  // gives role assignment, reused here for invitations.
+  const targetRolePermissions = await db('role_permissions')
+    .join('permissions', 'permissions.id', 'role_permissions.permission_id')
+    .where('role_permissions.role_id', role.id)
+    .pluck('permissions.name');
+  await assertActorMayGrant(invitedById, targetRolePermissions);
+
   // Generate secure invitation token (64 characters hex = 32 bytes)
   const token = crypto.randomBytes(32).toString('hex');
   const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000); // 7 days

--- a/backend/src/services/userManagementService.js
+++ b/backend/src/services/userManagementService.js
@@ -271,6 +271,16 @@ async function updateAdminUser(id, updates, updatedById, requestingAdmin = {}) {
       throw new ValidationError('Only Super Admins can assign the Super Admin role');
     }
 
+    // Privilege-escalation guard (GHSA-rv8w-m6mx-7j4q): holding `users.edit`
+    // must not let an actor hand out a role carrying permissions they don't
+    // themselves have — same containment assertActorMayGrant already gives
+    // `roles.manage` for role create/edit, reused here for role assignment.
+    const targetRolePermissions = await db('role_permissions')
+      .join('permissions', 'permissions.id', 'role_permissions.permission_id')
+      .where('role_permissions.role_id', role.id)
+      .pluck('permissions.name');
+    await assertActorMayGrant(updatedById, targetRolePermissions);
+
     // Prevent self-role-update
     if (id === updatedById) {
       throw new ValidationError('Cannot change your own role');


### PR DESCRIPTION
## Summary

Fixes a confirmed privilege-escalation vulnerability: any admin holding only the `users.edit` permission could grant an arbitrary non-super_admin role — including one carrying far more permissions than they themselves hold (e.g. a full `admin` role) — to any other account, via `PUT /api/admin/users/:id`.

**Root cause**: `userManagementService.js`'s `updateAdminUser` role-change branch only guarded against granting `super_admin` and against self/last-super_admin demotion — it never checked whether the *requesting* admin's own permissions covered the *target* role's permissions. The codebase already has `assertActorMayGrant(actorId, permissionNames)` enforcing exactly this containment for role create/edit (`roles.manage`), but it was never wired into the user-role-assignment path.

**Fix**: resolve the target role's permission list, then call the existing `assertActorMayGrant()` guard before applying the role change. Purely additive — all prior guards (super_admin-only-grants-super_admin, self-update block, last-super_admin protection) are untouched.

## Test plan
- [x] New test file: an actor holding only a subset of permissions cannot grant a role exceeding that subset (including the built-in `admin` role) — rejected; regression tests confirm granting a role within the actor's own permissions, and super_admin granting any role, both still work.
- [x] Full backend suite: 317 suites / 3453 tests passed, 0 failures, 5 pre-existing skips.
- [x] `npm run lint`: clean.
- [x] Local E2E smoke suite: 13/13 passed.