### PR TITLE
fix(upload): let the csrf gate pass application/octet-stream chunks

### DIFF
--- a/backend/__tests__/middleware/csrfChunkedUpload.test.js
+++ b/backend/__tests__/middleware/csrfChunkedUpload.test.js
@@ -1,0 +1,75 @@
+/**
+ * The chunked upload client posts each chunk as application/octet-stream and
+ * the route reads the raw request stream. The CSRF gate answered every such
+ * request 415 before it reached the route, so the endpoint never accepted a
+ * chunk (PicPeak/picpeak#1377).
+ *
+ * The gate's origin check is the CSRF defence. The Content-Type list only
+ * has to keep out what a cross-site page can send without a preflight, and
+ * application/octet-stream is not on that list: an HTML form cannot produce
+ * it and fetch() with it is not CORS-safelisted.
+ */
+const express = require('express');
+const request = require('supertest');
+
+jest.mock('../../src/utils/logger', () => ({ error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() }));
+
+function buildApp() {
+  const app = express();
+  // Same order as server.js: scoped JSON parser, then the gate on /api.
+  app.use(['/api/admin', '/api/v1'], express.json({ limit: '50mb' }));
+  app.use(express.json({ limit: '2mb' }));
+  app.use('/api', require('../../src/middleware/csrf'));
+  // Mirrors the chunk route in adminPhotos.js: consume the raw stream.
+  app.post('/api/admin/photos/:eventId/chunked-upload/:uploadId/chunk/:chunkIndex', async (req, res) => {
+    const chunks = [];
+    for await (const chunk of req) chunks.push(chunk);
+    res.json({ received: Buffer.concat(chunks).toString('base64') });
+  });
+  app.post('/api/admin/other', (req, res) => res.json({ body: req.body }));
+  return app;
+}
+
+const CHUNK_PATH = '/api/admin/photos/1/chunked-upload/abc/chunk/0';
+
+describe('CSRF gate and application/octet-stream', () => {
+  it('lets a same-origin octet-stream chunk reach the route byte for byte', async () => {
+    // Not valid UTF-8, so a text decode anywhere on the path would show up.
+    const payload = Buffer.concat([Buffer.from('chunkbytes'), Buffer.from([0xff, 0x00, 0xfe])]);
+    const res = await request(buildApp())
+      .post(CHUNK_PATH)
+      .set('sec-fetch-site', 'same-origin')
+      .set('Content-Type', 'application/octet-stream')
+      .send(payload);
+    expect(res.status).toBe(200);
+    expect(Buffer.from(res.body.received, 'base64').equals(payload)).toBe(true);
+  });
+
+  it('still rejects a cross-site octet-stream post on origin', async () => {
+    const res = await request(buildApp())
+      .post(CHUNK_PATH)
+      .set('sec-fetch-site', 'cross-site')
+      .set('Content-Type', 'application/octet-stream')
+      .send(Buffer.from('chunkbytes'));
+    expect(res.status).toBe(403);
+  });
+
+  it('still rejects the types a form can send', async () => {
+    const res = await request(buildApp())
+      .post('/api/admin/other')
+      .set('sec-fetch-site', 'same-origin')
+      .set('Content-Type', 'text/plain')
+      .send('x=1');
+    expect(res.status).toBe(415);
+  });
+
+  it('leaves a JSON route with an empty body on an octet-stream post', async () => {
+    const res = await request(buildApp())
+      .post('/api/admin/other')
+      .set('sec-fetch-site', 'same-origin')
+      .set('Content-Type', 'application/octet-stream')
+      .send(Buffer.from('{"a":1}'));
+    expect(res.status).toBe(200);
+    expect(res.body.body).toEqual({});
+  });
+});

--- a/backend/src/middleware/csrf.js
+++ b/backend/src/middleware/csrf.js
@@ -1,5 +1,12 @@
 const { mutationOriginAllowed } = require('../utils/requestOrigin');
 
+// The origin check is the CSRF defence. This list only has to keep out what
+// a cross-site page can send without a preflight: a form cannot produce JSON
+// or octet-stream, and fetch() with either is not CORS-safelisted.
+// octet-stream is how the chunked upload route receives its raw body
+// (#1377); express.json leaves it unread for everything else.
+const ALLOWED_CONTENT_TYPES = ['application/json', 'multipart/form-data', 'application/octet-stream'];
+
 module.exports = function csrfProtection(req, res, next) {
   if (!['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method)) return next();
   if (!mutationOriginAllowed(req)) {
@@ -7,9 +14,9 @@ module.exports = function csrfProtection(req, res, next) {
   }
   const contentType = (req.headers['content-type'] || '').split(';')[0].trim().toLowerCase();
   const hasBody = Number(req.headers['content-length']) > 0 || !!req.headers['transfer-encoding'];
-  const jsonLike = contentType === 'application/json' || contentType.endsWith('+json');
-  if (hasBody && !jsonLike && contentType !== 'multipart/form-data') {
-    return res.status(415).json({ error: 'Unsupported Content-Type. Use application/json or multipart/form-data.' });
+  const allowed = ALLOWED_CONTENT_TYPES.includes(contentType) || contentType.endsWith('+json');
+  if (hasBody && !allowed) {
+    return res.status(415).json({ error: `Unsupported Content-Type. Use ${ALLOWED_CONTENT_TYPES.join(', ')}.` });
   }
   next();
 };


### PR DESCRIPTION
## Description

The chunked upload endpoint has never accepted a chunk. The client posts each chunk as `application/octet-stream` and the route reads the raw request stream, but the CSRF gate on `/api` answers any non-JSON, non-multipart body with 415 before the request reaches the route or auth.

The gate's origin check is the CSRF defence. Its Content-Type list only has to keep out what a cross-site page can send without a preflight, and octet-stream is not one of those: an HTML form cannot produce it, and `fetch()` or `sendBeacon` with it is not CORS-safelisted, so the browser preflights and the origin check rejects it. This change adds `application/octet-stream` to the list. `express.json` leaves an octet-stream body unread, so JSON routes see `{}` as they do for a bodiless request.

The issue suggested mounting the chunk routes ahead of the gate. That also skips the origin check, the request logger, the maintenance gate and the session timeout for those routes, so I widened the gate instead. Client untouched.

Fixes PicPeak/picpeak#1377

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`backend/__tests__/middleware/csrfChunkedUpload.test.js`: same-origin octet-stream reaches a raw-stream route byte for byte (415 on `main`), cross-site octet-stream is still 403, `text/plain` is still 415, a JSON route sees an empty body on an octet-stream post. `galleryAccessPolicy` and `securityHardeningBatch2` still pass.

Manual, against this branch on SQLite: the issue's curl now gets 401 from auth instead of 415. Logged in, `init` then two octet-stream chunks then `complete` for a 73 byte PNG. Both chunks 200, `complete` created the photo, stored file is byte-identical to the source.

- [x] Unit tests pass (`npm test`)
- [x] Manual testing completed

**Test Configuration**:
* PicPeak Version: main (3.131.3-beta.0)
* Node.js Version: 24
* Database: SQLite
* Browser: n/a, curl

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes:

Now that chunks arrive, `adminPhotos.js` buffers each whole chunk in memory before `uploadChunk` applies the size cap. Behind `adminAuth` and `photos.upload`, pre-existing, not changed here.
