### PR TITLE
fix(video): regenerate missing thumbnails for already-uploaded videos

### DIFF
--- a/backend/__tests__/routes/galleryProtectedVideoUrls.test.js
+++ b/backend/__tests__/routes/galleryProtectedVideoUrls.test.js
@@ -160,4 +160,19 @@ describe('videos stay playable under enhanced/maximum protection (#1370)', () =>
       expect((await photoPayload(imageId)).url).toBe(`/api/gallery/${SLUG}/photo/${imageId}`);
     });
   });
+
+  // Both rows here were seeded with no thumbnail_path, which is the state
+  // every video uploaded before the pipeline gained its placeholder fallback
+  // is still in.
+  describe('a video with no stored thumbnail (#1414)', () => {
+    test('is still offered the thumbnail route, which regenerates it lazily', async () => {
+      const photo = await photoPayload(videoId);
+      expect(photo.thumbnail_url).toBe(`/api/gallery/${SLUG}/thumbnail/${videoId}`);
+    });
+
+    test('while a still image keeps falling back to its original', async () => {
+      const photo = await photoPayload(imageId);
+      expect(photo.thumbnail_url).toBeNull();
+    });
+  });
 });

--- a/backend/src/services/__tests__/imageProcessor.videoThumbnail.test.js
+++ b/backend/src/services/__tests__/imageProcessor.videoThumbnail.test.js
@@ -1,0 +1,131 @@
+/**
+ * Lazy thumbnail regeneration for videos (#1414).
+ *
+ * ensureThumbnail is the one path that repairs a photo row whose thumbnail is
+ * missing or unreadable — the gallery thumbnail route, the admin "regenerate
+ * thumbnails" button and the OG-image builder all go through it. It had no
+ * video branch, so it resolved the source and handed it to Sharp, which throws
+ * on an mp4. Videos that reached that state — uploaded before the upload
+ * pipeline learned to fall back to a placeholder, or with their rendition
+ * since lost — could never get a thumbnail back, however many times they were
+ * viewed or regenerated.
+ *
+ * They now go through the same processUploadedVideo a fresh upload uses, so
+ * regeneration yields the poster frame (or, if ffmpeg cannot read the file,
+ * the same SVG placeholder the upload path falls back to).
+ */
+
+jest.mock('../../utils/logger');
+jest.mock('../../database/db', () => {
+  const photosUpdate = jest.fn().mockResolvedValue(1);
+  const db = jest.fn((table) => {
+    if (table === 'events') {
+      return { where: () => ({ first: () => Promise.resolve({ id: 7, slug: 'summer-wedding' }) }) };
+    }
+    if (table === 'photos') {
+      return { where: () => ({ update: photosUpdate }) };
+    }
+    throw new Error(`unexpected table: ${table}`);
+  });
+  db.photosUpdate = photosUpdate;
+  return { db };
+});
+jest.mock('../storage', () => ({
+  getStorage: () => ({
+    kind: () => 'local',
+    resolveLocalPath: (key) => `/storage/${key}`
+  })
+}));
+jest.mock('../videoProcessor', () => ({
+  processUploadedVideo: jest.fn()
+}));
+jest.mock('../photoResolver', () => ({
+  resolvePhotoStorageKey: jest.fn(),
+  resolvePhotoFilePath: jest.fn()
+}));
+
+const { db } = require('../../database/db');
+const { processUploadedVideo } = require('../videoProcessor');
+const { resolvePhotoStorageKey, resolvePhotoFilePath } = require('../photoResolver');
+const { ensureThumbnail } = require('../imageProcessor');
+
+const managedVideo = {
+  id: 42,
+  event_id: 7,
+  filename: 'clip.mp4',
+  path: 'summer-wedding/individual/clip.mp4',
+  media_type: 'video',
+  mime_type: 'video/mp4',
+  thumbnail_path: null
+};
+
+describe('ensureThumbnail rebuilds a video thumbnail from the video (#1414)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resolvePhotoStorageKey.mockReturnValue('events/active/summer-wedding/individual/clip.mp4');
+    resolvePhotoFilePath.mockReturnValue('/mnt/nas/2026/clip.mp4');
+    processUploadedVideo.mockImplementation(async (_videoPath, thumbnailKey) => ({
+      success: true,
+      metadata: { duration: 12 },
+      thumbnailKey
+    }));
+  });
+
+  it('generates a poster frame for a managed video that has no thumbnail yet', async () => {
+    const result = await ensureThumbnail(managedVideo);
+
+    expect(processUploadedVideo).toHaveBeenCalledWith(
+      '/storage/events/active/summer-wedding/individual/clip.mp4',
+      'thumbnails/thumb_clip.jpg'
+    );
+    expect(result).toBe('thumbnails/thumb_clip.jpg');
+    expect(db.photosUpdate).toHaveBeenCalledWith({ thumbnail_path: 'thumbnails/thumb_clip.jpg' });
+  });
+
+  it('recognises a video by mime type alone, for rows predating media_type', async () => {
+    const { media_type: _unused, ...legacyRow } = managedVideo;
+
+    const result = await ensureThumbnail({ ...legacyRow, id: 43 });
+
+    expect(processUploadedVideo).toHaveBeenCalled();
+    expect(result).toBe('thumbnails/thumb_clip.jpg');
+  });
+
+  it('reads an external video straight off its mount, under a per-photo key', async () => {
+    const result = await ensureThumbnail({
+      ...managedVideo,
+      id: 44,
+      source_origin: 'external',
+      external_relpath: '2026/clip.mp4'
+    });
+
+    expect(resolvePhotoFilePath).toHaveBeenCalled();
+    expect(processUploadedVideo).toHaveBeenCalledWith(
+      '/mnt/nas/2026/clip.mp4',
+      'thumbnails/thumb_ext44_clip.jpg'
+    );
+    expect(result).toBe('thumbnails/thumb_ext44_clip.jpg');
+  });
+
+  it('returns null instead of throwing when the video cannot be thumbnailed at all', async () => {
+    processUploadedVideo.mockRejectedValue(new Error('storage backend down'));
+
+    await expect(ensureThumbnail({ ...managedVideo, id: 45 })).resolves.toBeNull();
+    expect(db.photosUpdate).not.toHaveBeenCalled();
+  });
+
+  it('leaves still images on the image path', async () => {
+    resolvePhotoStorageKey.mockImplementation(() => { throw new Error('resolved as an image'); });
+
+    const result = await ensureThumbnail({
+      ...managedVideo,
+      id: 46,
+      filename: 'still.jpg',
+      media_type: 'image',
+      mime_type: 'image/jpeg'
+    });
+
+    expect(processUploadedVideo).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+});

--- a/backend/src/services/galleryQueryService.js
+++ b/backend/src/services/galleryQueryService.js
@@ -488,7 +488,16 @@ async function getGalleryPhotos({ event, query = {}, identity, accessLevel, admi
         // The lightbox renders it when `use_original_filenames` is on.
         original_filename: photo.original_filename || null,
         url: photoUrl,
-        thumbnail_url: photo.thumbnail_path ? `/api/gallery/${slug}/thumbnail/${photo.id}${wmQuery}` : null,
+        // Videos are offered the thumbnail route even with no thumbnail_path
+        // recorded yet (#1414). The route regenerates lazily, and for a video
+        // it now produces a poster frame or the SVG placeholder rather than
+        // failing — whereas a null here makes every grid layout fall back to
+        // `thumbnail_url || url` and render the ORIGINAL VIDEO into an <img>,
+        // which is both a broken tile and a full download of the file. Images
+        // keep the old behaviour: for them the original is a usable fallback.
+        thumbnail_url: (photo.thumbnail_path || isVideo)
+          ? `/api/gallery/${slug}/thumbnail/${photo.id}${wmQuery}`
+          : null,
         // Hero-optimized image URL (1920x1080) for full-width hero sections
         hero_url: `/api/gallery/${slug}/hero/${photo.id}${wmQuery}`,
         // Lightbox preview URL (#492). Only emitted when the admin

--- a/backend/src/services/imageProcessor.js
+++ b/backend/src/services/imageProcessor.js
@@ -522,6 +522,17 @@ function singleFlight(key, fn, { force = false } = {}) {
 }
 
 /**
+ * Whether a photo row is a video.
+ *
+ * Both columns are checked because `media_type` was only backfilled for rows
+ * created after the video support landed; older rows carry nothing but the
+ * mime type.
+ */
+function isVideoPhoto(photo) {
+  return photo.media_type === 'video' || String(photo.mime_type || '').startsWith('video/');
+}
+
+/**
  * Regenerate thumbnail if it's broken or missing.
  *
  * Works for both managed photos (stored via the storage backend, possibly
@@ -556,7 +567,16 @@ async function regenerateThumbnail(photo) {
   const isExternal = photo.source_origin === 'external' || photo.source_origin === 'reference';
 
   let newThumbnailPath;
-  if (isExternal) {
+  if (isVideoPhoto(photo)) {
+    // A video's thumbnail is a poster frame, not a Sharp resize of the stored
+    // file (#1414). Without this branch the generic path below hands the mp4
+    // to Sharp, which throws, so every video whose row reached here with no
+    // usable thumbnail_path — uploaded before the upload pipeline learned to
+    // fall back to a placeholder, or with its rendition since lost — stayed
+    // thumbnail-less forever, however many times it was viewed or the admin
+    // pressed regenerate.
+    newThumbnailPath = await regenerateVideoThumbnail(event, photo, isExternal);
+  } else if (isExternal) {
     // External: source is on a local mount path. No withLocalCopy needed
     // (storage-backend abstraction doesn't apply — this is a direct fs
     // read). Use a per-photo unique outputBasename so two events both
@@ -601,6 +621,53 @@ async function regenerateThumbnail(photo) {
   }
 
   return null;
+}
+
+/**
+ * Rebuild a video's thumbnail from the source video.
+ *
+ * Same contract as the image branch of regenerateThumbnail: return the new
+ * storage key, or null when nothing could be produced. processUploadedVideo
+ * is the same routine the upload pipeline uses, so a regenerated thumbnail is
+ * byte-for-byte the one a fresh upload of that file would have got — a real
+ * poster frame, degrading to the ffmpeg-free SVG placeholder when ffmpeg
+ * cannot read the file, and throwing only when even that fails.
+ *
+ * The key mirrors the upload pipeline's (`thumbnails/thumb_<name>.jpg`) so a
+ * regeneration overwrites the previous rendition instead of orphaning it. The
+ * external branch keeps regenerateThumbnail's `ext<id>_` prefix, which is what
+ * stops two events that reference the same NAS basename from clobbering each
+ * other's thumbnail.
+ */
+async function regenerateVideoThumbnail(event, photo, isExternal) {
+  const { resolvePhotoStorageKey, resolvePhotoFilePath } = require('./photoResolver');
+  const { processUploadedVideo } = require('./videoProcessor');
+
+  const sourceBasename = path.basename(
+    (isExternal ? (photo.external_relpath || photo.filename) : photo.filename) || `video-${photo.id}`
+  );
+  const outputBasename = isExternal ? `ext${photo.id}_${sourceBasename}` : sourceBasename;
+  const thumbnailKey = path.posix.join('thumbnails', `thumb_${outputBasename.replace(/\.[^.]+$/, '.jpg')}`);
+
+  const generate = async (localPath) => {
+    const result = await processUploadedVideo(localPath, thumbnailKey);
+    return result?.thumbnailKey || null;
+  };
+
+  try {
+    if (isExternal) {
+      // Direct fs read off the mount, exactly like the external image branch.
+      const localPath = resolvePhotoFilePath(event, photo);
+      logger.info(`Ensuring thumbnail for external video ${photo.id} from ${localPath}`);
+      return await generate(localPath);
+    }
+    const sourceKey = resolvePhotoStorageKey(event, photo);
+    logger.info(`Ensuring thumbnail for video ${photo.id} from key: ${sourceKey}`);
+    return await withLocalCopy(sourceKey, generate);
+  } catch (e) {
+    logger.error(`Failed to regenerate thumbnail for video ${photo.id}: ${e.message}`);
+    return null;
+  }
 }
 
 async function generateVideoPlaceholder(originalFilename, options = {}) {
@@ -1135,7 +1202,7 @@ async function ensureThumbnailAtWidth(photo, width) {
   // hand the video itself to Sharp — after withLocalCopy has downloaded the
   // whole thing on an S3 backend. Nothing caches that failure, so a crawler
   // walking ?w= over a gallery of videos repeats the download every request.
-  if (photo.media_type === 'video' || String(photo.mime_type || '').startsWith('video/')) {
+  if (isVideoPhoto(photo)) {
     return ensureThumbnail(photo);
   }
 


### PR DESCRIPTION
## Description

Videos uploaded before the upload pipeline learned to fall back to a placeholder thumbnail still show up in galleries without one — a broken tile — while a video uploaded today gets its poster frame fine. Two things kept those older rows from ever recovering:

1. `ensureThumbnail()` is the path that repairs a row whose thumbnail is missing or unreadable (the gallery thumbnail route, the admin "regenerate thumbnails" button and the OG image builder all go through it), but it had no video branch: it resolved the source and handed it to Sharp, which throws on an mp4. So regeneration could never produce anything for a video. I gave it a video branch that runs the same `processUploadedVideo()` a fresh upload uses, so it gets the real poster frame, and the existing SVG placeholder fallback when ffmpeg cannot read the file. External/reference videos keep the per-photo `ext<id>_` key prefix the image branch already uses, and the key otherwise matches the upload pipeline's so a regeneration overwrites the old rendition instead of orphaning it.

2. The gallery payload only emitted `thumbnail_url` when `thumbnail_path` was already set, so for these rows the frontend never even called the route that would have repaired them — it fell back to `thumbnail_url || url` and rendered the original video file into an `<img>`. That is the broken tile in the report, and it also means opening the gallery downloads the whole video. Videos now always get the thumbnail URL; still images keep the old behaviour, since for them the original is a usable fallback.

No migration or backfill needed — the first view of an affected gallery regenerates and persists the thumbnail.

Fixes #1414

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `backend/src/services/__tests__/imageProcessor.videoThumbnail.test.js` (new): covers a managed video with no thumbnail, a legacy row identified only by `mime_type`, an external video's key, the failure path returning `null` rather than throwing, and a still image staying on the image path. Three of the five fail on the unpatched code.
- `backend/__tests__/routes/galleryProtectedVideoUrls.test.js`: two assertions on the gallery payload — a video with no `thumbnail_path` is still offered the thumbnail route, a still image is not.

**Test Configuration**:
* Database: SQLite / PostgreSQL
* Browser: n/a (backend only)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective

## Additional Notes:

Backend only, so no screenshot. `CHANGELOG.md` is left to release-please as CONTRIBUTING describes.
