### PR TITLE
fix(gallery): keep the video controls reachable while paused, and go fullscreen on iOS

### DIFF
--- a/frontend/src/components/gallery/VideoPlayer.tsx
+++ b/frontend/src/components/gallery/VideoPlayer.tsx
@@ -27,6 +27,7 @@ export const VideoPlayer: React.FC<VideoPlayerProps> = ({
 }) => {
   const { t } = useTranslation();
   const videoRef = useRef<HTMLVideoElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const [isPlaying, setIsPlaying] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [isMuted, setIsMuted] = useState(muted);
@@ -36,6 +37,10 @@ export const VideoPlayer: React.FC<VideoPlayerProps> = ({
   const [duration, setDuration] = useState(0);
   const [showControls, setShowControls] = useState(true);
   const controlsTimeoutRef = useRef<NodeJS.Timeout>();
+  // The hide timer reads these instead of state so it sees the value at the
+  // moment it fires, not the one captured when the mouse last moved.
+  const isPlayingRef = useRef(false);
+  const hoveringControlsRef = useRef(false);
 
   useEffect(() => {
     const video = videoRef.current;
@@ -50,9 +55,21 @@ export const VideoPlayer: React.FC<VideoPlayerProps> = ({
       setDuration(video.duration);
     };
 
-    const handlePlay = () => setIsPlaying(true);
-    const handlePause = () => setIsPlaying(false);
-    const handleEnded = () => setIsPlaying(false);
+    const handlePlay = () => {
+      isPlayingRef.current = true;
+      setIsPlaying(true);
+    };
+    // A paused video always shows its controls. Without this, a hide timer
+    // armed during playback fired after the pause and left the guest with
+    // no visible play or fullscreen button — every click then went to the
+    // <video> itself and just toggled playback.
+    const handlePause = () => {
+      isPlayingRef.current = false;
+      if (controlsTimeoutRef.current) clearTimeout(controlsTimeoutRef.current);
+      setIsPlaying(false);
+      setShowControls(true);
+    };
+    const handleEnded = () => handlePause();
 
     // Without this the element just sits on its poster at 0:00 and says
     // nothing (#1370) — a guest cannot tell a failed request from a codec
@@ -87,6 +104,24 @@ export const VideoPlayer: React.FC<VideoPlayerProps> = ({
     };
   }, [t]);
 
+  // Keep isFullscreen honest when the user leaves through Esc or the native
+  // UI rather than our button: the document-level event covers the desktop
+  // path, and iOS Safari only tells the <video> itself (webkitendfullscreen).
+  useEffect(() => {
+    const video = videoRef.current;
+    const handleFullscreenChange = () => {
+      setIsFullscreen(Boolean(document.fullscreenElement));
+    };
+    const handleWebkitEnd = () => setIsFullscreen(false);
+
+    document.addEventListener('fullscreenchange', handleFullscreenChange);
+    video?.addEventListener('webkitendfullscreen', handleWebkitEnd);
+    return () => {
+      document.removeEventListener('fullscreenchange', handleFullscreenChange);
+      video?.removeEventListener('webkitendfullscreen', handleWebkitEnd);
+    };
+  }, []);
+
   // Arrowing to the next video in the lightbox reuses this element, so a
   // stale error would otherwise stick to a clip that loads fine.
   useEffect(() => {
@@ -114,17 +149,32 @@ export const VideoPlayer: React.FC<VideoPlayerProps> = ({
 
   const toggleFullscreen = async () => {
     const video = videoRef.current;
-    if (!video) return;
+    const container = containerRef.current;
+    if (!video || !container) return;
 
     try {
       if (!isFullscreen) {
-        if (video.requestFullscreen) {
-          await video.requestFullscreen();
+        // Go fullscreen on the container so our controls come along. iPhone
+        // Safari has no Fullscreen API at all — only the video element's
+        // webkitEnterFullscreen, which hands off to the native player — so
+        // the button did nothing there before this fallback.
+        const el = container as HTMLElement & { webkitRequestFullscreen?: () => Promise<void> | void };
+        const nativeVideo = video as HTMLVideoElement & { webkitEnterFullscreen?: () => void };
+        if (el.requestFullscreen) {
+          await el.requestFullscreen();
+        } else if (el.webkitRequestFullscreen) {
+          await el.webkitRequestFullscreen();
+        } else if (nativeVideo.webkitEnterFullscreen) {
+          nativeVideo.webkitEnterFullscreen();
+          return; // state is set by webkitendfullscreen on exit
         }
         setIsFullscreen(true);
       } else {
-        if (document.exitFullscreen) {
-          await document.exitFullscreen();
+        const doc = document as Document & { webkitExitFullscreen?: () => Promise<void> | void };
+        if (doc.exitFullscreen) {
+          await doc.exitFullscreen();
+        } else if (doc.webkitExitFullscreen) {
+          await doc.webkitExitFullscreen();
         }
         setIsFullscreen(false);
       }
@@ -149,16 +199,33 @@ export const VideoPlayer: React.FC<VideoPlayerProps> = ({
     return `${mins}:${secs.toString().padStart(2, '0')}`;
   };
 
-  const handleMouseMove = () => {
-    setShowControls(true);
+  const scheduleHideControls = () => {
     if (controlsTimeoutRef.current) {
       clearTimeout(controlsTimeoutRef.current);
     }
     controlsTimeoutRef.current = setTimeout(() => {
-      if (isPlaying) {
+      // Resting the pointer on the bar must not hide it out from under the
+      // cursor — that is where the pointer is when someone is about to
+      // click pause or fullscreen.
+      if (isPlayingRef.current && !hoveringControlsRef.current) {
         setShowControls(false);
       }
     }, 3000);
+  };
+
+  const handleMouseMove = () => {
+    setShowControls(true);
+    scheduleHideControls();
+  };
+
+  const handleControlsMouseEnter = () => {
+    hoveringControlsRef.current = true;
+    setShowControls(true);
+  };
+
+  const handleControlsMouseLeave = () => {
+    hoveringControlsRef.current = false;
+    scheduleHideControls();
   };
 
   useEffect(() => {
@@ -171,10 +238,14 @@ export const VideoPlayer: React.FC<VideoPlayerProps> = ({
 
   return (
     <div
+      ref={containerRef}
       className={`relative bg-black rounded-lg overflow-hidden ${className}`}
       style={{ width, height: height === 'auto' ? undefined : height }}
       onMouseMove={handleMouseMove}
-      onMouseLeave={() => isPlaying && setShowControls(false)}
+      onMouseLeave={() => {
+        hoveringControlsRef.current = false;
+        if (isPlayingRef.current) setShowControls(false);
+      }}
     >
       <video
         ref={videoRef}
@@ -200,8 +271,10 @@ export const VideoPlayer: React.FC<VideoPlayerProps> = ({
       {controls && !loadError && (
         <div
           className={`absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 to-transparent p-4 transition-opacity duration-300 ${
-            showControls ? 'opacity-100' : 'opacity-0'
+            showControls ? 'opacity-100' : 'opacity-0 pointer-events-none'
           }`}
+          onMouseEnter={handleControlsMouseEnter}
+          onMouseLeave={handleControlsMouseLeave}
         >
           {/* Progress bar */}
           <div
@@ -249,12 +322,15 @@ export const VideoPlayer: React.FC<VideoPlayerProps> = ({
         </div>
       )}
 
-      {/* Play button overlay when paused */}
+      {/* Play button overlay when paused. It renders after the control bar,
+          so it must not capture clicks itself: while paused the fullscreen,
+          mute and progress controls were unreachable underneath it, and a
+          click on the poster went to this div instead of the <video>. */}
       {!isPlaying && showControls && !loadError && (
-        <div className="absolute inset-0 flex items-center justify-center">
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
           <button
             onClick={togglePlayPause}
-            className="bg-black/50 hover:bg-black/70 text-white rounded-full p-6 transition-colors"
+            className="pointer-events-auto bg-black/50 hover:bg-black/70 text-white rounded-full p-6 transition-colors"
             aria-label="Play"
           >
             <Play size={48} fill="white" />

--- a/frontend/src/components/gallery/VideoPlayer.tsx
+++ b/frontend/src/components/gallery/VideoPlayer.tsx
@@ -105,19 +105,26 @@ export const VideoPlayer: React.FC<VideoPlayerProps> = ({
   }, [t]);
 
   // Keep isFullscreen honest when the user leaves through Esc or the native
-  // UI rather than our button: the document-level event covers the desktop
-  // path, and iOS Safari only tells the <video> itself (webkitendfullscreen).
+  // UI rather than our button. Browsers with only the prefixed API (the
+  // webkitRequestFullscreen path below) fire webkitfullscreenchange and
+  // expose webkitFullscreenElement instead of the standard pair; iOS Safari
+  // only tells the <video> itself (webkitendfullscreen). Compare against our
+  // own container so another element going fullscreen does not flip us.
   useEffect(() => {
     const video = videoRef.current;
     const handleFullscreenChange = () => {
-      setIsFullscreen(Boolean(document.fullscreenElement));
+      const doc = document as Document & { webkitFullscreenElement?: Element | null };
+      const active = document.fullscreenElement || doc.webkitFullscreenElement || null;
+      setIsFullscreen(active !== null && active === containerRef.current);
     };
     const handleWebkitEnd = () => setIsFullscreen(false);
 
     document.addEventListener('fullscreenchange', handleFullscreenChange);
+    document.addEventListener('webkitfullscreenchange', handleFullscreenChange);
     video?.addEventListener('webkitendfullscreen', handleWebkitEnd);
     return () => {
       document.removeEventListener('fullscreenchange', handleFullscreenChange);
+      document.removeEventListener('webkitfullscreenchange', handleFullscreenChange);
       video?.removeEventListener('webkitendfullscreen', handleWebkitEnd);
     };
   }, []);

--- a/frontend/src/components/gallery/__tests__/VideoPlayer.pausedControls.test.tsx
+++ b/frontend/src/components/gallery/__tests__/VideoPlayer.pausedControls.test.tsx
@@ -84,6 +84,32 @@ describe('VideoPlayer paused-state controls', () => {
     expect(screen.getByLabelText('Fullscreen')).toBeInTheDocument();
   });
 
+  it('syncs an Esc exit on browsers that only fire the prefixed event', async () => {
+    const { container } = render(<VideoPlayer src="/api/gallery/e/photo/1" />);
+    const root = container.firstElementChild as FullscreenTarget;
+    root.requestFullscreen = undefined;
+    root.webkitRequestFullscreen = vi.fn().mockResolvedValue(undefined);
+
+    fireEvent.click(screen.getByLabelText('Fullscreen'));
+    await vi.waitFor(() => expect(screen.getByLabelText('Exit fullscreen')).toBeInTheDocument());
+
+    fireEvent(document, new Event('webkitfullscreenchange'));
+    expect(screen.getByLabelText('Fullscreen')).toBeInTheDocument();
+  });
+
+  it('ignores another element entering fullscreen', async () => {
+    const { container } = render(<VideoPlayer src="/api/gallery/e/photo/1" />);
+    const other = document.createElement('div');
+    Object.defineProperty(document, 'fullscreenElement', { value: other, configurable: true });
+    try {
+      fireEvent(document, new Event('fullscreenchange'));
+      expect(screen.getByLabelText('Fullscreen')).toBeInTheDocument();
+      expect(container.querySelector('video')).toBeInTheDocument();
+    } finally {
+      Object.defineProperty(document, 'fullscreenElement', { value: null, configurable: true });
+    }
+  });
+
   it('keeps the controls visible after a pause, even if a hide was already scheduled', () => {
     vi.useFakeTimers();
     try {

--- a/frontend/src/components/gallery/__tests__/VideoPlayer.pausedControls.test.tsx
+++ b/frontend/src/components/gallery/__tests__/VideoPlayer.pausedControls.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * While paused, the centre play overlay must not swallow the control bar.
+ *
+ * The overlay is `absolute inset-0` and renders after the control bar, so it
+ * sat on top of the fullscreen, mute and progress controls whenever the video
+ * was paused — which is exactly when a guest reaches for fullscreen. Clicks
+ * landed on the overlay's wrapper div and did nothing.
+ *
+ * Fullscreen also only ever tried `video.requestFullscreen()`, which iPhone
+ * Safari does not implement (it only offers `webkitEnterFullscreen` on the
+ * video element), so the maximize button was a no-op there.
+ *
+ * The auto-hide timer made it worse on desktop: it captured `isPlaying` when
+ * the mouse last moved, so pausing within three seconds of a mouse move hid
+ * the controls anyway, and resting the pointer on the bar to click pause let
+ * the bar fade out from under the cursor.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { act } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { VideoPlayer } from '../VideoPlayer';
+
+type FullscreenTarget = HTMLElement & {
+  requestFullscreen?: () => Promise<void>;
+  webkitRequestFullscreen?: () => Promise<void>;
+};
+
+describe('VideoPlayer paused-state controls', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('lets clicks through the paused overlay to the control bar', () => {
+    render(<VideoPlayer src="/api/gallery/e/photo/1" />);
+
+    const [transportPlay, centrePlay] = screen.getAllByLabelText('Play');
+    const overlay = centrePlay.parentElement!;
+
+    expect(overlay.className).toContain('pointer-events-none');
+    expect(centrePlay.className).toContain('pointer-events-auto');
+    // The transport button lives in the control bar, not under the overlay.
+    expect(overlay.contains(transportPlay)).toBe(false);
+  });
+
+  it('goes fullscreen on the container so the custom controls come along', async () => {
+    const { container } = render(<VideoPlayer src="/api/gallery/e/photo/1" />);
+    const root = container.firstElementChild as FullscreenTarget;
+    const request = vi.fn().mockResolvedValue(undefined);
+    root.requestFullscreen = request;
+
+    fireEvent.click(screen.getByLabelText('Fullscreen'));
+    await vi.waitFor(() => expect(screen.getByLabelText('Exit fullscreen')).toBeInTheDocument());
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to webkitEnterFullscreen on the video (iPhone Safari)', async () => {
+    const { container } = render(<VideoPlayer src="/api/gallery/e/photo/1" />);
+    const root = container.firstElementChild as FullscreenTarget;
+    root.requestFullscreen = undefined;
+    root.webkitRequestFullscreen = undefined;
+    const video = container.querySelector('video') as HTMLVideoElement & {
+      webkitEnterFullscreen?: () => void;
+    };
+    const enter = vi.fn();
+    video.webkitEnterFullscreen = enter;
+
+    fireEvent.click(screen.getByLabelText('Fullscreen'));
+    await vi.waitFor(() => expect(enter).toHaveBeenCalledTimes(1));
+    // The native player owns the state until it fires webkitendfullscreen.
+    expect(screen.getByLabelText('Fullscreen')).toBeInTheDocument();
+  });
+
+  it('drops the fullscreen state when the user exits with Esc', async () => {
+    const { container } = render(<VideoPlayer src="/api/gallery/e/photo/1" />);
+    const root = container.firstElementChild as FullscreenTarget;
+    root.requestFullscreen = vi.fn().mockResolvedValue(undefined);
+
+    fireEvent.click(screen.getByLabelText('Fullscreen'));
+    await vi.waitFor(() => expect(screen.getByLabelText('Exit fullscreen')).toBeInTheDocument());
+
+    // jsdom never sets fullscreenElement; Esc leaves it null, as it would be.
+    fireEvent(document, new Event('fullscreenchange'));
+    expect(screen.getByLabelText('Fullscreen')).toBeInTheDocument();
+  });
+
+  it('keeps the controls visible after a pause, even if a hide was already scheduled', () => {
+    vi.useFakeTimers();
+    try {
+      const { container } = render(<VideoPlayer src="/api/gallery/e/photo/1" />);
+      const video = container.querySelector('video')!;
+      const root = container.firstElementChild as HTMLElement;
+
+      fireEvent.play(video);
+      fireEvent.mouseMove(root); // arms the 3s hide while playing
+      fireEvent.pause(video); // guest clicks the video to pause
+      act(() => {
+        vi.advanceTimersByTime(3500);
+      });
+
+      const bar = screen.getByLabelText('Fullscreen').closest('div.absolute')!;
+      expect(bar.className).toContain('opacity-100');
+      expect(screen.getAllByLabelText('Play')).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not hide the bar while the pointer is resting on it', () => {
+    vi.useFakeTimers();
+    try {
+      const { container } = render(<VideoPlayer src="/api/gallery/e/photo/1" />);
+      const video = container.querySelector('video')!;
+      const root = container.firstElementChild as HTMLElement;
+      const bar = screen.getByLabelText('Fullscreen').closest('div.absolute')!;
+
+      fireEvent.play(video);
+      fireEvent.mouseMove(root);
+      fireEvent.mouseEnter(bar);
+      act(() => {
+        vi.advanceTimersByTime(3500);
+      });
+      expect(bar.className).toContain('opacity-100');
+
+      fireEvent.mouseLeave(bar);
+      act(() => {
+        vi.advanceTimersByTime(3500);
+      });
+      expect(bar.className).toContain('opacity-0');
+      // A faded bar must not intercept the click that reaches for the video.
+      expect(bar.className).toContain('pointer-events-none');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
## Description

Three related problems in the guest `VideoPlayer`, all reproduced on a self-hosted stable 3.46.13 install and fixed together because they share the same surface:

1. **The paused-state play overlay blocked the control bar.** The centre play overlay is `absolute inset-0` and renders after the control bar, so while the video was paused it sat on top of the fullscreen, mute and progress controls and swallowed their clicks. A click on the poster went to the overlay's wrapper div instead of the `<video>`. The wrapper is now `pointer-events-none` and only the button is `pointer-events-auto`.
2. **The auto-hide timer read stale state.** `handleMouseMove` captured `isPlaying` at the time of the last mouse move, so pausing within three seconds of a move hid the controls anyway — leaving no visible play or fullscreen button, with every click going to the `<video>` and toggling playback. And resting the pointer on the bar to click pause let the bar fade out from under the cursor. Pausing now always reveals the controls, the timer reads the live state through refs, hover on the bar defers the hide, and a faded bar is `pointer-events-none` so it can't intercept clicks.
3. **Fullscreen was a no-op on iPhone Safari.** `toggleFullscreen` only ever called `video.requestFullscreen()`, which iOS Safari does not implement. Fullscreen is now requested on the container (so the custom controls come along), falling back to `webkitRequestFullscreen`, then to the video element's `webkitEnterFullscreen` (native iOS player). `fullscreenchange` / `webkitendfullscreen` listeners keep `isFullscreen` in sync when the user exits with Esc or the native UI.

No changes to the lightbox, to protection levels, or to how the video URL is resolved.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests pass (`npm test`) — `VideoPlayer.pausedControls.test.tsx` adds 6 tests (overlay click-through, container fullscreen, iOS fallback, Esc sync, pause-reveals-controls with a hide already scheduled, hover defers hide); the existing `VideoPlayer.loadError.test.tsx` still passes (11/11 for the component). `eslint` and `tsc --noEmit` clean for the touched files.
- [x] Manual testing completed
- [x] Tested on Docker deployment
- [x] Tested on production-like environment — built into the frontend image of a self-hosted stable 3.46.13 install; verified play/pause/mute/fullscreen while paused and while hovering the bar on desktop Chrome, and playback + fullscreen on iOS Safari.

**Test Configuration**:
* PicPeak Version: stable 3.46.13 (patch applies cleanly to `main`, this PR is against `main`)
* Node.js Version: 22
* Database: PostgreSQL
* Browser: Chrome (desktop), Safari (iOS)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — n/a
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published — none
- [ ] I have updated the CHANGELOG.md file — release-please generates it

## Additional Notes:

On `stable` there is a fourth, separate cause for "dead controls" on desktop: the lightbox's translucent bottom toolbar overlays the media area, and a landscape video's control bar lands underneath it. That is already fixed on `main` by #892 and is not part of this PR; I've opened a separate issue asking for its backport to `stable`.
