### PR TITLE
fix(frontend): allow blob: in the CSP media-src directive

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -147,7 +147,7 @@ const cspDirectives = {
   connectSrc: ["'self'", 'https://www.google.com', 'https://www.gstatic.com'], // API connections
   fontSrc: ["'self'", "https:", "data:"], // Web fonts
   objectSrc: ["'none'"], // Disable plugins
-  mediaSrc: ["'self'"], // Audio/video
+  mediaSrc: ["'self'", "blob:"], // Audio/video, incl. page-created blobs (matches imgSrc)
   frameSrc: ["'self'", 'https://www.google.com'],
 };
 // Only upgrade insecure requests when HSTS explicitly enabled (HTTPS deployment)

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -56,7 +56,7 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https:; img-src 'self' data: https: blob:; connect-src 'self' https://www.google.com https://www.gstatic.com; font-src 'self' https: data:; object-src 'none'; media-src 'self'; frame-src 'self' https://www.google.com" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https:; img-src 'self' data: https: blob:; connect-src 'self' https://www.google.com https://www.gstatic.com; font-src 'self' https: data:; object-src 'none'; media-src 'self' blob:; frame-src 'self' https://www.google.com" always;
 
     # Strip the same headers when emitted by the upstream backend so nginx
     # is the single source. Without this, helmet (in the Express app) and
@@ -86,7 +86,7 @@ server {
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https:; img-src 'self' data: https: blob:; connect-src 'self' https://www.google.com https://www.gstatic.com; font-src 'self' https: data:; object-src 'none'; media-src 'self'; frame-src 'self' https://www.google.com" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https:; img-src 'self' data: https: blob:; connect-src 'self' https://www.google.com https://www.gstatic.com; font-src 'self' https: data:; object-src 'none'; media-src 'self' blob:; frame-src 'self' https://www.google.com" always;
     }
 
     # Cache index.html with revalidation
@@ -98,7 +98,7 @@ server {
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https:; img-src 'self' data: https: blob:; connect-src 'self' https://www.google.com https://www.gstatic.com; font-src 'self' https: data:; object-src 'none'; media-src 'self'; frame-src 'self' https://www.google.com" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https:; img-src 'self' data: https: blob:; connect-src 'self' https://www.google.com https://www.gstatic.com; font-src 'self' https: data:; object-src 'none'; media-src 'self' blob:; frame-src 'self' https://www.google.com" always;
     }
 
     # Analytics tracker proxy (backend). The tracker script is served from our


### PR DESCRIPTION
## Description

`AdminAuthenticatedVideo` fetches the file with the auth header and plays it through `URL.createObjectURL(...)`, i.e. a `blob:` URL. The frontend nginx CSP already allows `blob:` in `img-src` for the same pattern (`AdminAuthenticatedImage`), but `media-src` was `'self'` only, so the browser refused the source. The symptom is a grey player with no error in the UI — only a CSP violation in the console — which is easy to mistake for a codec or MIME problem.

This adds `blob:` to `media-src` in the three CSP strings in `frontend/nginx.conf`. Same exposure as the existing `img-src blob:` — only blobs created by the page itself.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manual testing completed
- [x] Tested on Docker deployment
- [x] Tested on production-like environment — running on a self-hosted stable install since 3.45.0 (July) via a patched `default.conf`, now built into the frontend image on 3.46.13. Admin lightbox video playback works with the header; the CSP violation is gone. `nginx -t` passes.

**Test Configuration**:
* PicPeak Version: stable 3.45.0 → 3.46.13
* Node.js Version: 22
* Database: PostgreSQL
* Browser: Chrome, Safari

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code — config-only change
- [ ] I have made corresponding changes to the documentation — n/a
- [x] My changes generate no new warnings
- [ ] I have added tests — nginx config, not covered by the test suites
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published — none
- [ ] I have updated the CHANGELOG.md file — release-please generates it
